### PR TITLE
optimize: product list views

### DIFF
--- a/counter/templates/counter/product_list.jinja
+++ b/counter/templates/counter/product_list.jinja
@@ -8,25 +8,17 @@
   {% if current_tab == "products" %}
     <p><a href="{{ url('counter:new_product') }}">{% trans %}New product{% endtrans %}</a></p>
   {% endif %}
-  {% if product_list %}
-    <h3>{% trans %}Product list{% endtrans %}</h3>
-    {% for t in ProductType.objects.all().order_by('name') %}
-      <h4>{{ t }}</h4>
-      <ul>
-        {% for p in product_list.filter(product_type=t).all().order_by('name') %}
-          <li><a href="{{ url('counter:product_edit', product_id=p.id) }}">{{ p }} ({{ p.code }})</a></li>
-        {% endfor %}
-      </ul>
-    {% endfor %}
-    <h4>{% trans %}Uncategorized{% endtrans %}</h4>
+  <h3>{% trans %}Product list{% endtrans %}</h3>
+  {%- for product_type, products in object_list -%}
+    <h4>{{ product_type or _("Uncategorized") }}</h4>
     <ul>
-      {% for p in product_list.filter(product_type=None).all().order_by('name') %}
-        <li><a href="{{ url('counter:product_edit', product_id=p.id) }}">{{ p }} ({{ p.code }})</a></li>
-      {% endfor %}
+      {%- for product in products -%}
+        <li><a href="{{ url('counter:product_edit', product_id=product.id) }}">{{ product }} ({{ product.code }})</a></li>
+      {%- endfor -%}
     </ul>
-  {% else %}
+  {%- else -%}
     {% trans %}There is no products in this website.{% endtrans %}
-  {% endif %}
+  {%- endfor -%}
 {% endblock %}
 
 

--- a/counter/urls.py
+++ b/counter/urls.py
@@ -19,11 +19,7 @@ from counter.views import *
 
 urlpatterns = [
     path("<int:counter_id>/", CounterMain.as_view(), name="details"),
-    path(
-        "<int:counter_id>/click/<int:user_id>/",
-        CounterClick.as_view(),
-        name="click",
-    ),
+    path("<int:counter_id>/click/<int:user_id>/", CounterClick.as_view(), name="click"),
     path(
         "<int:counter_id>/last_ops/",
         CounterLastOperationsView.as_view(),
@@ -34,19 +30,11 @@ urlpatterns = [
         CounterCashSummaryView.as_view(),
         name="cash_summary",
     ),
-    path(
-        "<int:counter_id>/activity/",
-        CounterActivityView.as_view(),
-        name="activity",
-    ),
+    path("<int:counter_id>/activity/", CounterActivityView.as_view(), name="activity"),
     path("<int:counter_id>/stats/", CounterStatView.as_view(), name="stats"),
     path("<int:counter_id>/login/", counter_login, name="login"),
     path("<int:counter_id>/logout/", counter_logout, name="logout"),
-    path(
-        "eticket/<int:selling_id>/pdf/",
-        EticketPDFView.as_view(),
-        name="eticket_pdf",
-    ),
+    path("eticket/<int:selling_id>/pdf/", EticketPDFView.as_view(), name="eticket_pdf"),
     path(
         "customer/<int:customer_id>/card/add/",
         StudentCardFormView.as_view(),
@@ -59,17 +47,11 @@ urlpatterns = [
     ),
     path("admin/<int:counter_id>/", CounterEditView.as_view(), name="admin"),
     path(
-        "admin/<int:counter_id>/prop/",
-        CounterEditPropView.as_view(),
-        name="prop_admin",
+        "admin/<int:counter_id>/prop/", CounterEditPropView.as_view(), name="prop_admin"
     ),
     path("admin/", CounterListView.as_view(), name="admin_list"),
     path("admin/new/", CounterCreateView.as_view(), name="new"),
-    path(
-        "admin/delete/<int:counter_id>/",
-        CounterDeleteView.as_view(),
-        name="delete",
-    ),
+    path("admin/delete/<int:counter_id>/", CounterDeleteView.as_view(), name="delete"),
     path("admin/invoices_call/", InvoiceCallView.as_view(), name="invoices_call"),
     path(
         "admin/cash_summary/list/",
@@ -81,10 +63,10 @@ urlpatterns = [
         CashSummaryEditView.as_view(),
         name="cash_summary_edit",
     ),
-    path("admin/product/list/", ProductListView.as_view(), name="product_list"),
+    path("admin/product/list/", ActiveProductListView.as_view(), name="product_list"),
     path(
         "admin/product/list_archived/",
-        ProductArchivedListView.as_view(),
+        ArchivedProductListView.as_view(),
         name="product_list_archived",
     ),
     path("admin/product/create/", ProductCreateView.as_view(), name="new_product"),


### PR DESCRIPTION
La requête pour obtenir la page des produits prend actuellement 900ms en moyenne. Celle des produits archivés prend 2.5s en moyenne.

Pour optimiser ça, j'ai réorganisé les vues pour obtenir tous les résultats en une seule requête, contre 2*n actuellement (où n est le nombre total de types de produits sur le site) et j'ai fait en sorte de trim le `ul`, histoire de raccourcir la réponse.