### PR TITLE
Test sentry-debug endpoint

### DIFF
--- a/sith/settings.py
+++ b/sith/settings.py
@@ -724,7 +724,8 @@ if DEBUG:
         "debug_toolbar.panels.signals.SignalsPanel",
         "debug_toolbar.panels.redirects.RedirectsPanel",
     ]
-    SENTRY_ENV = "development"
+    if not TESTING:
+        SENTRY_ENV = "development"  # We can't test if it gets overridden in settings
 
 if TESTING:
     CAPTCHA_TEST_MODE = True

--- a/sith/tests.py
+++ b/sith/tests.py
@@ -1,0 +1,32 @@
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+from _pytest.python_api import RaisesContext
+from django.test import Client
+from django.test.utils import override_settings
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("sentry_dsn", "sentry_env", "expected_error", "expected_return_code"),
+    [
+        # Working case
+        ("something", "development", pytest.raises(ZeroDivisionError), None),
+        # View is disabled when DSN isn't defined or environment isn't development
+        ("something", "production", does_not_raise(), 404),
+        ("", "development", does_not_raise(), 404),
+        ("", "production", does_not_raise(), 404),
+    ],
+)
+def test_sentry_debug_endpoint(
+    client: Client,
+    sentry_dsn: str,
+    sentry_env: str,
+    expected_error: RaisesContext[ZeroDivisionError] | does_not_raise[None],
+    expected_return_code: int | None,
+):
+    with expected_error, override_settings(
+        SENTRY_DSN=sentry_dsn, SENTRY_ENV=sentry_env
+    ):
+        assert client.get(reverse("sentry-debug")).status_code == expected_return_code

--- a/sith/urls.py
+++ b/sith/urls.py
@@ -17,6 +17,7 @@ from ajax_select import urls as ajax_select_urls
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.http import Http404
 from django.urls import include, path
 from django.views.i18n import JavaScriptCatalog
 from ninja_extra import NinjaExtraAPI
@@ -71,11 +72,12 @@ if settings.DEBUG:
 
     urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]
 
-if settings.SENTRY_ENV == "development" and settings.SENTRY_DSN:
+
+def sentry_debug(request):
     """Sentry debug endpoint
 
     This function always crash and allows us to test
-    the sentry configuration and the modal popup 
+    the sentry configuration and the modal popup
     displayed to users on production
 
     The error will be displayed on Sentry
@@ -83,8 +85,9 @@ if settings.SENTRY_ENV == "development" and settings.SENTRY_DSN:
 
     NOTE : you need to specify the SENTRY_DSN setting in settings_custom.py
     """
+    if settings.SENTRY_ENV != "development" or not settings.SENTRY_DSN:
+        raise Http404
+    _division_by_zero = 1 / 0
 
-    def raise_exception(request):
-        _division_by_zero = 1 / 0
 
-    urlpatterns += [path("sentry-debug/", raise_exception)]
+urlpatterns += [path("sentry-debug/", sentry_debug, name="sentry-debug")]


### PR DESCRIPTION
J'ai du rendre l'endpoint testable et fixer les settings qui me bloquaient en mode test.

On peut pas complêtement éviter de mettre l'endpoint dans les urls sinon c'est jamais rechargé dans les tests et c'est impossible à tester.