### PR TITLE
optimize product pages again

### DIFF
--- a/counter/templates/counter/product_list.jinja
+++ b/counter/templates/counter/product_list.jinja
@@ -13,7 +13,7 @@
     <h4>{{ product_type or _("Uncategorized") }}</h4>
     <ul>
       {%- for product in products -%}
-        <li><a href="{{ url('counter:product_edit', product_id=product.id) }}">{{ product }} ({{ product.code }})</a></li>
+        <li><a href="{{ url('counter:product_edit', product_id=product.id) }}">{{ product.name }} ({{ product.code }})</a></li>
       {%- endfor -%}
     </ul>
   {%- else -%}

--- a/counter/views.py
+++ b/counter/views.py
@@ -17,7 +17,7 @@ import re
 from datetime import datetime, timedelta
 from datetime import timezone as tz
 from http import HTTPStatus
-from operator import attrgetter
+from operator import itemgetter
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs
 
@@ -801,7 +801,7 @@ class ProductTypeEditView(CounterAdminTabsMixin, CounterAdminMixin, UpdateView):
 
 class ProductListView(CounterAdminTabsMixin, CounterAdminMixin, ListView):
     model = Product
-    queryset = Product.objects.annotate(type_name=F("product_type__name"))
+    queryset = Product.objects.values("id", "name", "code", "product_type__name")
     template_name = "counter/product_list.jinja"
     ordering = [
         F("product_type__priority").desc(nulls_last=True),
@@ -812,7 +812,7 @@ class ProductListView(CounterAdminTabsMixin, CounterAdminMixin, ListView):
     def get_context_data(self, **kwargs):
         res = super().get_context_data(**kwargs)
         res["object_list"] = itertools.groupby(
-            res["object_list"], key=attrgetter("type_name")
+            res["object_list"], key=itemgetter("product_type__name")
         )
         return res
 


### PR DESCRIPTION
La page des produits est toujours un peu lente à charger. Mais on peut encore accélérer ça en sélectionnant les valeurs à sélectionner. Ca diminue le volume retourné par la db et ça évite d'initialiser les instances de modèle. On peut gagner jusqu'à 500ms de temps de chargement avec ça.

A l'avenir, il faudra remédier à ce problème en mettant un affichage un peu plus lazy des produits. Mais pour le moment ça  permet de gagner un peu sans changer l'UX.