### PR TITLE
core: fix user profile picture size

### DIFF
--- a/core/static/user/user_detail.scss
+++ b/core/static/user/user_detail.scss
@@ -170,6 +170,7 @@ main {
       align-items: center;
       gap: 20px;
       flex-grow: 1;
+      flex-basis: 14em;
 
       @media (max-width: 960px) {
         flex-direction: row;

--- a/core/static/user/user_detail.scss
+++ b/core/static/user/user_detail.scss
@@ -130,7 +130,7 @@ main {
     width: 50%;
     display: flex;
     flex-direction: row;
-    justify-content: flex-end;
+    justify-content: space-evenly;
 
     @media (max-width: 960px) {
       width: 100%;
@@ -143,21 +143,14 @@ main {
     }
 
     > .user_profile_pictures_bigone {
-      flex-grow: 9;
-      flex-basis: 20em;
       display: flex;
       justify-content: center;
-      align-items: center;
 
       > img {
         max-height: 100%;
-        max-width: 100%;
-        object-fit: contain;
 
         @media (max-width: 960px) {
-          max-width: 300px;
-          width: 100%;
-          object-fit: contain;
+          width: 300px;
         }
       }
     }
@@ -169,8 +162,6 @@ main {
       justify-content: center;
       align-items: center;
       gap: 20px;
-      flex-grow: 1;
-      flex-basis: 14em;
 
       @media (max-width: 960px) {
         flex-direction: row;


### PR DESCRIPTION
Since 28f397574f7b7ef54914972ed0154ce879128a3b and the removal of the `flex-basis: 50px` property from `user_profile_pictures_thumbnails`, the main picture was always displayed small-ish, at least on Firefox. Setting back a flex-basis helps getting more consistent behavior once again.

Before this fix:
![image](https://github.com/user-attachments/assets/6d5b3140-cf02-46a7-a75d-e66cbf96e671)
After this fix:
![image](https://github.com/user-attachments/assets/81a027bf-f5d1-4b79-8803-6af8f2527cbe)
