### PR TITLE
Remove honeypot from login page

### DIFF
--- a/core/templates/core/login.jinja
+++ b/core/templates/core/login.jinja
@@ -33,7 +33,6 @@
     {% endif %}
 
     {% csrf_token %}
-    {% render_honeypot_field %}
 
     <div>
       <label for="{{ form.username.name }}">{{ form.username.label }}</label>

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -146,39 +146,20 @@ class TestUserLogin:
         """Should not login a user correctly."""
         response = client.post(
             reverse("core:login"),
-            {
-                "username": user.username,
-                "password": "wrong-password",
-                settings.HONEYPOT_FIELD_NAME: settings.HONEYPOT_VALUE,
-            },
+            {"username": user.username, "password": "wrong-password"},
         )
         assert response.status_code == 200
         assert (
             '<p class="alert alert-red">Votre nom d\'utilisateur '
             "et votre mot de passe ne correspondent pas. Merci de réessayer.</p>"
         ) in str(response.content.decode())
-
-    def test_login_honeypot(self, client, user):
-        response = client.post(
-            reverse("core:login"),
-            {
-                "username": user.username,
-                "password": "wrong-password",
-                settings.HONEYPOT_FIELD_NAME: settings.HONEYPOT_VALUE + "incorrect",
-            },
-        )
-        assert response.status_code == 200
         assert response.wsgi_request.user.is_anonymous
 
     def test_login_success(self, client, user):
         """Should login a user correctly."""
         response = client.post(
             reverse("core:login"),
-            {
-                "username": user.username,
-                "password": "plop",
-                settings.HONEYPOT_FIELD_NAME: settings.HONEYPOT_VALUE,
-            },
+            {"username": user.username, "password": "plop"},
         )
         assertRedirects(response, reverse("core:index"))
         assert response.wsgi_request.user == user

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -77,7 +77,6 @@ from subscription.models import Subscription
 from trombi.views import UserTrombiForm
 
 
-@method_decorator(check_honeypot, name="post")
 class SithLoginView(views.LoginView):
     """The login View."""
 


### PR DESCRIPTION
Des utilisateurs humains se font régulièrement "éclairer" par le honeypot. Les mesures anti-bot ne devraient pas bloquer des humains.