### PR TITLE
fix access to the subscription page

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -530,10 +530,8 @@ class User(AbstractBaseUser):
 
     @cached_property
     def can_create_subscription(self) -> bool:
-        from club.models import Membership
-
-        return (
-            Membership.objects.board()
+        return self.is_root or (
+            self.memberships.board()
             .ongoing()
             .filter(club_id__in=settings.SITH_CAN_CREATE_SUBSCRIPTIONS)
             .exists()

--- a/subscription/tests/test_new_susbcription.py
+++ b/subscription/tests/test_new_susbcription.py
@@ -90,13 +90,20 @@ def test_form_new_user(settings: SettingsWrapper):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "user_factory", [lambda: baker.make(User, is_superuser=True), board_user.make]
+    ("user_factory", "status_code"),
+    [
+        (lambda: baker.make(User, is_superuser=True), 200),
+        (board_user.make, 200),
+        (subscriber_user.make, 403),
+    ],
 )
-def test_load_page(client: Client, user_factory: Callable[[], User]):
-    """Just check the page doesn't crash."""
+def test_page_access(
+    client: Client, user_factory: Callable[[], User], status_code: int
+):
+    """Check that only authorized users may access this page."""
     client.force_login(user_factory())
     res = client.get(reverse("subscription:subscription"))
-    assert res.status_code == 200
+    assert res.status_code == status_code
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Depuis l'arrivée en prod de #932, la page des cotisations est accessible à n'importe qui. C'est incroyablement critique, mais on l'a hotfix, donc cette PR n'est pas non plus à déployer tout de suite.

On a vérifié toutes les cotisations créées depuis cette mise en prod, et heureusement on n'en a trouvé aucune qui semble frauduleuse.