### PR TITLE
Fix groups displayed on user profile group edition

### DIFF
--- a/core/views/forms.py
+++ b/core/views/forms.py
@@ -44,7 +44,7 @@ from phonenumber_field.widgets import RegionalPhoneNumberWidget
 from PIL import Image
 
 from antispam.forms import AntiSpamEmailField
-from core.models import Gift, Page, SithFile, User
+from core.models import Gift, Page, RealGroup, SithFile, User
 from core.utils import resize_image
 from core.views.widgets.select import (
     AutoCompleteSelect,
@@ -285,15 +285,18 @@ class UserProfileForm(forms.ModelForm):
         self._post_clean()
 
 
-class UserPropForm(forms.ModelForm):
+class UserRealGroupForm(forms.ModelForm):
     error_css_class = "error"
     required_css_class = "required"
+
+    groups = forms.ModelChoiceField(
+        RealGroup.objects.all(),
+        widget=CheckboxSelectMultiple,
+    )
 
     class Meta:
         model = User
         fields = ["groups"]
-        help_texts = {"groups": "Which groups this user belongs to"}
-        widgets = {"groups": CheckboxSelectMultiple}
 
 
 class UserGodfathersForm(forms.Form):

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -35,7 +35,6 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.db.models import DateField, QuerySet
 from django.db.models.functions import Trunc
-from django.forms import CheckboxSelectMultiple
 from django.forms.models import modelform_factory
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
@@ -69,6 +68,7 @@ from core.views.forms import (
     RegisteringForm,
     UserGodfathersForm,
     UserProfileForm,
+    UserRealGroupForm,
 )
 from counter.models import Refilling, Selling
 from counter.views.student_card import StudentCardFormView
@@ -583,9 +583,7 @@ class UserUpdateGroupView(UserTabsMixin, CanEditPropMixin, UpdateView):
     model = User
     pk_url_kwarg = "user_id"
     template_name = "core/user_group.jinja"
-    form_class = modelform_factory(
-        User, fields=["groups"], widgets={"groups": CheckboxSelectMultiple}
-    )
+    form_class = UserRealGroupForm
     context_object_name = "profile"
     current_tab = "groups"
 


### PR DESCRIPTION
Après la migration vers le AbstractUser, on s'est mis à afficher tous les groupes sur la page d'édition des groupes d'un utilisateur
On veut pas ça alors j'ai fixé le formulaire