### PR TITLE
Fix error when submitting group form without any group checked

### DIFF
--- a/core/views/forms.py
+++ b/core/views/forms.py
@@ -293,6 +293,7 @@ class UserGroupsForm(forms.ModelForm):
         queryset=RealGroup.objects.all(),
         widget=CheckboxSelectMultiple,
         label=_("Groups"),
+        required=False,
     )
 
     class Meta:


### PR DESCRIPTION
Il y a un petit bug qui fait qu'on peut pas retirer tous ses groupes à un utilisateur