### PR TITLE
Give default groups to users

### DIFF
--- a/club/tests.py
+++ b/club/tests.py
@@ -213,9 +213,9 @@ class TestMembershipQuerySet(TestClub):
             memberships[1].club.members_group,
             memberships[1].club.board_group,
         }
-        assert set(user.groups.all()) == club_groups
+        assert set(user.groups.all()).issuperset(club_groups)
         user.memberships.all().delete()
-        assert user.groups.all().count() == 0
+        assert set(user.groups.all()).isdisjoint(club_groups)
 
 
 class TestClubModel(TestClub):

--- a/core/models.py
+++ b/core/models.py
@@ -384,8 +384,6 @@ class User(AbstractUser):
             return True
         if group.id == settings.SITH_GROUP_SUBSCRIBERS_ID:
             return self.is_subscribed
-        if group.id == settings.SITH_GROUP_OLD_SUBSCRIBERS_ID:
-            return self.was_subscribed
         if group.id == settings.SITH_GROUP_ROOT_ID:
             return self.is_root
         return group in self.cached_groups

--- a/core/tests/test_user.py
+++ b/core/tests/test_user.py
@@ -187,3 +187,11 @@ def test_generate_username(first_name: str, last_name: str, expected: str):
     new_user = User(first_name=first_name, last_name=last_name, email="a@example.com")
     new_user.generate_username()
     assert new_user.username == expected
+
+
+@pytest.mark.django_db
+def test_user_added_to_public_group():
+    """Test that newly created users are added to the public group"""
+    user = baker.make(User)
+    assert user.groups.filter(pk=settings.SITH_GROUP_PUBLIC_ID).exists()
+    assert user.is_in_group(pk=settings.SITH_GROUP_PUBLIC_ID)

--- a/rootplace/tests/test_merge_users.py
+++ b/rootplace/tests/test_merge_users.py
@@ -14,6 +14,7 @@
 #
 from datetime import timedelta
 
+from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.timezone import localtime, now
@@ -71,10 +72,12 @@ class TestMergeUser(TestCase):
         assert self.to_keep.nick_name == "B'ian"
         assert self.to_keep.address == "Jerusalem"
         assert self.to_keep.parent_address == "Rome"
-        assert self.to_keep.groups.count() == 3
-        groups = sorted(self.to_keep.groups.all(), key=lambda i: i.id)
-        expected = sorted([subscribers, mde_admin, sas_admin], key=lambda i: i.id)
-        assert groups == expected
+        assert set(self.to_keep.groups.values_list("id", flat=True)) == {
+            settings.SITH_GROUP_PUBLIC_ID,
+            subscribers.id,
+            mde_admin.id,
+            sas_admin.id,
+        }
 
     def test_both_subscribers_and_with_account(self):
         Customer(user=self.to_keep, account_id="11000l", amount=0).save()

--- a/subscription/models.py
+++ b/subscription/models.py
@@ -76,8 +76,11 @@ class Subscription(models.Model):
         super().save()
         from counter.models import Customer
 
-        _, created = Customer.get_or_create(self.member)
-        if created:
+        _, account_created = Customer.get_or_create(self.member)
+        if account_created:
+            # Someone who subscribed once will be considered forever
+            # as an old subscriber.
+            self.member.groups.add(settings.SITH_GROUP_OLD_SUBSCRIBERS_ID)
             form = PasswordResetForm({"email": self.member.email})
             if form.is_valid():
                 form.save(


### PR DESCRIPTION
Attribue par défaut le groupe "Public" aux utilisateurs nouvellement créés, et le groupe "Anciens Cotisants" lorsque les utilisateurs cotisent pour la première fois.