### PR TITLE
Fix product fetch

### DIFF
--- a/counter/static/bundled/counter/product-list-index.ts
+++ b/counter/static/bundled/counter/product-list-index.ts
@@ -108,7 +108,7 @@ document.addEventListener("alpine:init", () => {
           // biome-ignore lint/style/useNamingConvention: api is in snake_case
           is_archived: isArchived,
           // biome-ignore lint/style/useNamingConvention: api is in snake_case
-          product_type: this.productTypes,
+          product_type: [...this.productTypes],
         },
       };
     },


### PR DESCRIPTION
L'appel à `paginated` ne fonctionnait pas pour récupérer les produits, parce que certains des paramètres passés à la fonction n'étaient pas clonables.