### PR TITLE
Pin poetry version

### DIFF
--- a/.github/actions/setup_project/action.yml
+++ b/.github/actions/setup_project/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install Poetry
       if: steps.cached-poetry.outputs.cache-hit != 'true'
       shell: bash
-      run: curl -sSL https://install.python-poetry.org | python3 -
+      run: curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
 
     - name: Check pyproject.toml syntax
       shell: bash

--- a/docs/tutorial/install.md
+++ b/docs/tutorial/install.md
@@ -81,7 +81,7 @@ cd /mnt/<la_lettre_du_disque>/vos/fichiers/comme/dhab
                  libffi-dev python-dev-is-python3 pkg-config \
                  gettext git pipx
 
-        pipx install poetry
+        pipx install poetry==1.8.5
         ```
 
     === "Arch Linux"
@@ -101,7 +101,7 @@ cd /mnt/<la_lettre_du_disque>/vos/fichiers/comme/dhab
     
     ```bash    
     brew install git python pipx npm
-    pipx install poetry
+    pipx install poetry==1.8.5
     
     # Pour bien configurer gettext
     brew link gettext # (suivez bien les instructions supplémentaires affichées)


### PR DESCRIPTION
Poetry vient tout juste de passer à sa version 2.0.0.
Et on avait pas pin notre version de Poetry.
Et notre CI vient de casser.

Skill issue, un peu.

Je répare ça de façon un peu rapide et sale. On verra plus tard pour régler ce problème et faire proprement le passage à poetry 2.0 (ou à UV :sunglasses:)