### PR TITLE
Fix inconsistent search behavior on counter click codes

### DIFF
--- a/counter/static/bundled/counter/components/counter-product-select-index.ts
+++ b/counter/static/bundled/counter/components/counter-product-select-index.ts
@@ -76,7 +76,15 @@ export class CounterProductSelect extends AutoCompleteSelectBase {
     return {
       ...super.tomSelectSettings(),
       openOnFocus: false,
-      searchField: ["code", "text"],
+      // We make searching on exact code matching a higher priority
+      // We need to manually set weights or it results on an inconsistent
+      // behavior between production and development environment
+      searchField: [
+        // @ts-ignore documentation says it's fine, specified type is wrong
+        { field: "code", weight: 2 },
+        // @ts-ignore documentation says it's fine, specified type is wrong
+        { field: "text", weight: 0.5 },
+      ],
     };
   }
 }


### PR DESCRIPTION
La recherche par code retournait des résultats différents en prod et preprod par rapport à la version de dev.

Avant
<img width="450" alt="image" src="https://github.com/user-attachments/assets/38fac891-531d-43a7-9cc4-0dae6397c395" />
![image](https://github.com/user-attachments/assets/8a4003ce-28ac-4602-9f3f-7bc8bac4dfa5)

Après
![image](https://github.com/user-attachments/assets/535a3885-a2ab-43af-8a67-4aaecfb4005d)
<img width="317" alt="image" src="https://github.com/user-attachments/assets/513efd8f-c895-42b0-8792-6ae4e47dd3f5" />


