### PR TITLE
Improve pedagogy permissions

### DIFF
--- a/club/views.py
+++ b/club/views.py
@@ -256,7 +256,7 @@ class ClubMembersView(ClubTabsMixin, CanViewMixin, DetailFormView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["request_user"] = self.request.user
-        kwargs["club"] = self.get_object()
+        kwargs["club"] = self.object
         kwargs["club_members"] = self.members
         return kwargs
 
@@ -273,9 +273,9 @@ class ClubMembersView(ClubTabsMixin, CanViewMixin, DetailFormView):
         users = data.pop("users", [])
         users_old = data.pop("users_old", [])
         for user in users:
-            Membership(club=self.get_object(), user=user, **data).save()
+            Membership(club=self.object, user=user, **data).save()
         for user in users_old:
-            membership = self.get_object().get_membership_for(user)
+            membership = self.object.get_membership_for(user)
             membership.end_date = timezone.now()
             membership.save()
         return resp
@@ -285,9 +285,7 @@ class ClubMembersView(ClubTabsMixin, CanViewMixin, DetailFormView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_success_url(self, **kwargs):
-        return reverse_lazy(
-            "club:club_members", kwargs={"club_id": self.get_object().id}
-        )
+        return reverse_lazy("club:club_members", kwargs={"club_id": self.object.id})
 
 
 class ClubOldMembersView(ClubTabsMixin, CanViewMixin, DetailView):

--- a/core/management/commands/populate.py
+++ b/core/management/commands/populate.py
@@ -895,13 +895,16 @@ Welcome to the wiki page!
 
         subscribers = Group.objects.create(name="Subscribers")
         subscribers.permissions.add(
-            *list(perms.filter(codename__in=["add_news", "add_uvcommentreport"]))
+            *list(perms.filter(codename__in=["add_news", "add_uvcomment"]))
         )
         old_subscribers = Group.objects.create(name="Old subscribers")
         old_subscribers.permissions.add(
             *list(
                 perms.filter(
                     codename__in=[
+                        "view_uv",
+                        "view_uvcomment",
+                        "add_uvcommentreport",
                         "view_user",
                         "view_picture",
                         "view_album",
@@ -973,9 +976,9 @@ Welcome to the wiki page!
         )
         pedagogy_admin.permissions.add(
             *list(
-                perms.filter(content_type__app_label="pedagogy").values_list(
-                    "pk", flat=True
-                )
+                perms.filter(content_type__app_label="pedagogy")
+                .exclude(codename__in=["change_uvcomment"])
+                .values_list("pk", flat=True)
             )
         )
         self.reset_index("core", "auth")

--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -28,8 +28,7 @@ from django.http import (
     HttpResponseServerError,
 )
 from django.shortcuts import render
-from django.utils.functional import cached_property
-from django.views.generic.detail import SingleObjectMixin
+from django.views.generic.detail import BaseDetailView
 from django.views.generic.edit import FormView
 from sentry_sdk import last_event_id
 
@@ -54,17 +53,12 @@ def internal_servor_error(request):
     return HttpResponseServerError(render(request, "core/500.jinja"))
 
 
-class DetailFormView(SingleObjectMixin, FormView):
+class DetailFormView(FormView, BaseDetailView):
     """Class that allow both a detail view and a form view."""
 
-    def get_object(self):
-        """Get current group from id in url."""
-        return self.cached_object
-
-    @cached_property
-    def cached_object(self):
-        """Optimisation on group retrieval."""
-        return super().get_object()
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        return super().post(request, *args, **kwargs)
 
 
 # F403: those star-imports would be hellish to refactor

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -66,7 +66,6 @@ from core.views.forms import (
 )
 from core.views.mixins import QuickNotifMixin, TabedViewMixin
 from counter.models import Refilling, Selling
-from counter.views.student_card import StudentCardFormView
 from eboutic.models import Invoice
 from subscription.models import Subscription
 from trombi.views import UserTrombiForm
@@ -566,6 +565,8 @@ class UserPreferencesView(UserTabsMixin, CanEditMixin, UpdateView):
         if not hasattr(self.object, "trombi_user"):
             kwargs["trombi_form"] = UserTrombiForm()
         if hasattr(self.object, "customer"):
+            from counter.views.student_card import StudentCardFormView
+
             kwargs["student_card_fragment"] = StudentCardFormView.get_template_data(
                 self.object.customer
             ).render(self.request)

--- a/pedagogy/templates/pedagogy/guide.jinja
+++ b/pedagogy/templates/pedagogy/guide.jinja
@@ -19,7 +19,7 @@
 {% endblock head %}
 
 {% block content %}
-  {% if can_create_uv %}
+  {% if user.has_perm("pedagogy.add_uv") %}
     <div class="action-bar">
       <p>
         <a href="{{ url('pedagogy:uv_create') }}">{% trans %}Create UV{% endtrans %}</a>
@@ -94,8 +94,10 @@
           <td>{% trans %}Credit type{% endtrans %}</td>
           <td><i class="fa fa-leaf"></i></td>
           <td><i class="fa-regular fa-sun"></i></td>
-          {% if can_create_uv %}
+          {%- if user.has_perm("pedagogy.change_uv") -%}
             <td>{% trans %}Edit{% endtrans %}</td>
+          {%- endif -%}
+          {%- if user.has_perm("pedagogy.delete_uv") -%}
             <td>{% trans %}Delete{% endtrans %}</td>
           {% endif %}
         </tr>
@@ -109,8 +111,10 @@
             <td x-text="uv.credit_type"></td>
             <td><i :class="uv.semester.includes('AUTUMN') && 'fa fa-leaf'"></i></td>
             <td><i :class="uv.semester.includes('SPRING') && 'fa-regular fa-sun'"></i></td>
-            {% if can_create_uv -%}
+            {%- if user.has_perm("pedagogy.change_uv") -%}
               <td><a :href="`/pedagogy/uv/${uv.id}/edit`">{% trans %}Edit{% endtrans %}</a></td>
+            {%- endif -%}
+            {%- if user.has_perm("pedagogy.delete_uv") -%}
               <td><a :href="`/pedagogy/uv/${uv.id}/delete`">{% trans %}Delete{% endtrans %}</a></td>
             {%- endif -%}
           </tr>

--- a/pedagogy/templates/pedagogy/uv_detail.jinja
+++ b/pedagogy/templates/pedagogy/uv_detail.jinja
@@ -89,7 +89,7 @@
         <div id="leave_comment_not_allowed">
           <p>{% trans %}You already posted a comment on this UV. If you want to comment again, please modify or delete your previous comment.{% endtrans %}</p>
         </div>
-      {% else %}
+      {% elif user.has_perm("pedagogy.add_uvcomment") %}
         <div id="leave_comment">
           <h2>{% trans %}Leave comment{% endtrans %}</h2>
           <div>
@@ -146,9 +146,9 @@
       {% endif %}
       <br>
 
-      {% if object.comments.exists() %}
+      {% if comments %}
         <h2>{% trans %}Comments{% endtrans %}</h2>
-        {% for comment in object.comments.order_by("-publish_date").all() %}
+        {% for comment in comments %}
           <div id="{{ comment.id }}" class="comment-container">
 
             <div class="grade-block">
@@ -183,16 +183,28 @@
                 </p>
               {% endif %}
 
-              {% if user.is_owner(comment) %}
+              {% if comment.author_id == user.id or user.has_perm("pedagogy.change_comment") %}
                 <p class="actions">
-                  <a href="{{ url('pedagogy:comment_update', comment_id=comment.id) }}">{% trans %}Edit{% endtrans %}</a>
-                  <a href="{{ url('pedagogy:comment_delete', comment_id=comment.id) }}">{% trans %}Delete{% endtrans %}</a>
+                  <a href="{{ url('pedagogy:comment_update', comment_id=comment.id) }}">
+                    {% trans %}Edit{% endtrans %}
+                  </a>
+              {% endif %}
+              {% if comment.author_id == user.id or user.has_perm("pedagogy.delete_comment") %}
+                <a href="{{ url('pedagogy:comment_delete', comment_id=comment.id) }}">
+                  {% trans %}Delete{% endtrans %}
+                </a>
                 </p>
               {% endif %}
             </div>
 
             <div class="comment-end-bar">
-              <div class="report"><p><a href="{{ url('pedagogy:comment_report', comment_id=comment.id) }}">{% trans %}Report this comment{% endtrans %}</a></p></div>
+              <div class="report">
+                <p>
+                  <a href="{{ url('pedagogy:comment_report', comment_id=comment.id) }}">
+                    {% trans %}Report this comment{% endtrans %}
+                  </a>
+                </p>
+              </div>
 
               <div class="date"><p>{{ comment.publish_date.strftime('%d/%m/%Y') }}</p></div>
 
@@ -209,7 +221,7 @@
   <script type="text/javascript">
     $("#return_noscript").hide();
     $("#return_js").show();
-    var icons = {
+    const icons = {
       header: "fa fa-toggle-right",
       activeHeader: "fa fa-toggle-down"
     };


### PR DESCRIPTION
Passage de nos perms maison vers les perms du framework pour la pédagogie.
Ca s'y prête assez bien, puisqu'il n'y a aucune histoire de club : les admins pédagogie voient tout, les autres voient seulement ce qui est modéré et ce qu'ils ont écrit.

Ca va permettre une gestion plus fine des permissions, avec pour objectif :
- les anciens cotisants peuvent voir les UEs et les commentaires modérés.
- les cotisants peuvent ajouter et signaler des commentaires
- les admins pédagogie peuvent tout voir et tout faire, sauf éditer les commentaires des autres utilisateurs
- les auteurs de commentaire peuvent voir leur commentaire, même s'il a été signalé.

Tout ça est indicatif. C'est configurable directement depuis l'interface admin. On peut rajouter ou retirer une permission en deux clics.