### PR TITLE
fix `CustomerQuerySet.update_balance`

### DIFF
--- a/counter/models.py
+++ b/counter/models.py
@@ -52,7 +52,8 @@ class CustomerQuerySet(models.QuerySet):
     def update_amount(self) -> int:
         """Update the amount of all customers selected by this queryset.
 
-        The result is given as the sum of all refills minus the sum of all purchases.
+        The result is given as the sum of all refills
+        minus the sum of all purchases paid with the AE account.
 
         Returns:
             The number of updated rows.
@@ -73,7 +74,9 @@ class CustomerQuerySet(models.QuerySet):
             .values("res")
         )
         money_out = Subquery(
-            Selling.objects.filter(customer=OuterRef("pk"))
+            Selling.objects.filter(
+                customer=OuterRef("pk"), payment_method="SITH_ACCOUNT"
+            )
             .values("customer_id")
             .annotate(res=Sum(F("unit_price") * F("quantity"), default=0))
             .values("res")

--- a/counter/tests/test_customer.py
+++ b/counter/tests/test_customer.py
@@ -442,6 +442,7 @@ def test_update_balance():
             _quantity=len(customers),
             unit_price=10,
             quantity=1,
+            payment_method="SITH_ACCOUNT",
             _save_related=True,
         ),
         *sale_recipe.prepare(
@@ -449,10 +450,26 @@ def test_update_balance():
             _quantity=3,
             unit_price=5,
             quantity=2,
+            payment_method="SITH_ACCOUNT",
             _save_related=True,
         ),
         sale_recipe.prepare(
-            customer=customers[4], quantity=1, unit_price=50, _save_related=True
+            customer=customers[4],
+            quantity=1,
+            unit_price=50,
+            payment_method="SITH_ACCOUNT",
+            _save_related=True,
+        ),
+        *sale_recipe.prepare(
+            # all customers also bought products without using their AE account.
+            # All purchases made with another mean than the AE account should
+            # be ignored when updating the account balance.
+            customer=iter(customers),
+            _quantity=len(customers),
+            unit_price=50,
+            quantity=1,
+            payment_method="CARD",
+            _save_related=True,
         ),
     ]
     Selling.objects.bulk_create(sales)


### PR DESCRIPTION
On ne sélectionnait pas bien les achats (on prenait tout, y compris les achats faits par carte, qui ne peuvent pas être contrebalancés par un rechargement).

Heureusement, cette fonction n'est pas (encore) appelée en prod ailleurs que pour fusionner des utilisateurs, donc il ne devrait pas y avoir eu de conséquences.