### PR TITLE
Allow displaying more news

### DIFF
--- a/club/schemas.py
+++ b/club/schemas.py
@@ -7,3 +7,17 @@ class ClubSchema(ModelSchema):
     class Meta:
         model = Club
         fields = ["id", "name"]
+
+
+class ClubProfileSchema(ModelSchema):
+    """The infos needed to display a simple club profile."""
+
+    class Meta:
+        model = Club
+        fields = ["id", "name", "logo"]
+
+    url: str
+
+    @staticmethod
+    def resolve_url(obj: Club) -> str:
+        return obj.get_absolute_url()

--- a/com/schemas.py
+++ b/com/schemas.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+from ninja import FilterSchema, ModelSchema
+from ninja_extra import service_resolver
+from ninja_extra.controllers import RouteContext
+from pydantic import Field
+
+from club.schemas import ClubProfileSchema
+from com.models import News, NewsDate
+from core.markdown import markdown
+
+
+class NewsDateFilterSchema(FilterSchema):
+    before: datetime | None = Field(None, q="end_date__lt")
+    after: datetime | None = Field(None, q="start_date__gt")
+    club_id: int | None = Field(None, q="news__club_id")
+    news_id: int | None = None
+    is_moderated: bool | None = Field(None, q="news__is_moderated")
+    title: str | None = Field(None, q="news__title__icontains")
+
+
+class NewsSchema(ModelSchema):
+    class Meta:
+        model = News
+        fields = ["id", "title", "summary", "is_moderated"]
+
+    club: ClubProfileSchema
+    url: str
+
+    @staticmethod
+    def resolve_summary(obj: News) -> str:
+        # if this is returned from a route that allows the
+        # user to choose the text format (md or html)
+        # and the user chose "html", convert the markdown to html
+        context: RouteContext = service_resolver(RouteContext)
+        if context.kwargs.get("text_format", "") == "html":
+            return markdown(obj.summary)
+        return obj.summary
+
+    @staticmethod
+    def resolve_url(obj: News) -> str:
+        return obj.get_absolute_url()
+
+
+class NewsDateSchema(ModelSchema):
+    """Basic infos about an event occurrence.
+
+    Warning:
+        This uses [NewsSchema][], which itself
+        uses [ClubProfileSchema][club.schemas.ClubProfileSchema].
+        Don't forget the appropriated `select_related`.
+    """
+
+    class Meta:
+        model = NewsDate
+        fields = ["id", "start_date", "end_date"]
+
+    news: NewsSchema

--- a/com/static/bundled/com/components/moderation-alert-index.ts
+++ b/com/static/bundled/com/components/moderation-alert-index.ts
@@ -1,5 +1,5 @@
 import { exportToHtml } from "#core:utils/globals";
-import { newsDeleteNews, newsModerateNews } from "#openapi";
+import { newsDeleteNews, newsFetchNewsDates, newsModerateNews } from "#openapi";
 
 // This will be used in jinja templates,
 // so we cannot use real enums as those are purely an abstraction of Typescript
@@ -24,6 +24,7 @@ document.addEventListener("alpine:init", () => {
       // biome-ignore lint/style/useNamingConvention: api is snake case
       await newsModerateNews({ path: { news_id: this.newsId } });
       this.state = AlertState.MODERATED;
+      this.$dispatch("news-moderated", { newsId: this.newsId, state: this.state });
       this.loading = false;
     },
 
@@ -32,7 +33,36 @@ document.addEventListener("alpine:init", () => {
       // biome-ignore lint/style/useNamingConvention: api is snake case
       await newsDeleteNews({ path: { news_id: this.newsId } });
       this.state = AlertState.DELETED;
+      this.$dispatch("news-moderated", { newsId: this.newsId, state: this.state });
       this.loading = false;
+    },
+
+    /**
+     * Event receiver for when news dates are moderated.
+     *
+     * If the moderated date is linked to the same news
+     * as the one this moderation alert is attached to,
+     * then set the alert state to the same as the moderated one.
+     */
+    dispatchModeration(event: CustomEvent) {
+      if (event.detail.newsId === this.newsId) {
+        this.state = event.detail.state;
+      }
+    },
+
+    /**
+     * Query the server to know the number of news dates that would be moderated
+     * if this one is moderated.
+     */
+    async nbModerated() {
+      // What we want here is the count attribute of the response.
+      // We don't care about the actual results,
+      // so we ask for the minimum page size possible.
+      const response = await newsFetchNewsDates({
+        // biome-ignore lint/style/useNamingConvention: api is snake-case
+        query: { news_id: this.newsId, page: 1, page_size: 1 },
+      });
+      return response.data.count;
     },
   }));
 });

--- a/com/static/bundled/com/components/moderation-alert-index.ts
+++ b/com/static/bundled/com/components/moderation-alert-index.ts
@@ -64,5 +64,16 @@ document.addEventListener("alpine:init", () => {
       });
       return response.data.count;
     },
+
+    weeklyEventWarningMessage(nbEvents: number): string {
+      return interpolate(
+        gettext(
+          "This event will take place every week for %s weeks. " +
+            "If you moderate or delete this event, " +
+            "it will also be moderated (or deleted) for the following weeks.",
+        ),
+        [nbEvents],
+      );
+    },
   }));
 });

--- a/com/static/bundled/com/components/moderation-alert-index.ts
+++ b/com/static/bundled/com/components/moderation-alert-index.ts
@@ -54,7 +54,7 @@ document.addEventListener("alpine:init", () => {
      * Query the server to know the number of news dates that would be moderated
      * if this one is moderated.
      */
-    async nbModerated() {
+    async nbToModerate(): Promise<number> {
       // What we want here is the count attribute of the response.
       // We don't care about the actual results,
       // so we ask for the minimum page size possible.

--- a/com/static/bundled/com/components/upcoming-news-loader-index.ts
+++ b/com/static/bundled/com/components/upcoming-news-loader-index.ts
@@ -1,0 +1,67 @@
+import { type NewsDateSchema, newsFetchNewsDates } from "#openapi";
+
+interface ParsedNewsDateSchema extends Omit<NewsDateSchema, "start_date" | "end_date"> {
+  // biome-ignore lint/style/useNamingConvention: api is snake_case
+  start_date: Date;
+  // biome-ignore lint/style/useNamingConvention: api is snake_case
+  end_date: Date;
+}
+
+document.addEventListener("alpine:init", () => {
+  Alpine.data("upcomingNewsLoader", (startDate: Date) => ({
+    startDate: startDate,
+    currentPage: 1,
+    pageSize: 6,
+    hasNext: true,
+    loading: false,
+    newsDates: [] as NewsDateSchema[],
+
+    async loadMore() {
+      this.loading = true;
+      const response = await newsFetchNewsDates({
+        query: {
+          after: this.startDate.toISOString(),
+          // biome-ignore lint/style/useNamingConvention: api is snake_case
+          text_format: "html",
+          page: this.currentPage,
+          // biome-ignore lint/style/useNamingConvention: api is snake_case
+          page_size: this.pageSize,
+        },
+      });
+      if (response.response.status === 404) {
+        this.hasNext = false;
+      } else if (response.data.next === null) {
+        this.newsDates.push(...response.data.results);
+        this.hasNext = false;
+      } else {
+        this.newsDates.push(...response.data.results);
+        this.currentPage += 1;
+      }
+      this.loading = false;
+    },
+
+    groupedDates(): Record<string, NewsDateSchema[]> {
+      return this.newsDates
+        .map(
+          (date: NewsDateSchema): ParsedNewsDateSchema => ({
+            ...date,
+            // biome-ignore lint/style/useNamingConvention: api is snake_case
+            start_date: new Date(date.start_date),
+            // biome-ignore lint/style/useNamingConvention: api is snake_case
+            end_date: new Date(date.end_date),
+          }),
+        )
+        .reduce(
+          (acc: Record<string, ParsedNewsDateSchema[]>, date: ParsedNewsDateSchema) => {
+            const key = date.start_date.toDateString();
+            if (!acc[key]) {
+              acc[key] = [];
+            }
+            acc[key].push(date);
+            return acc;
+          },
+          {},
+        );
+    },
+  }));
+});

--- a/com/static/com/css/news-list.scss
+++ b/com/static/com/css/news-list.scss
@@ -51,6 +51,13 @@
     }
   }
 
+  /* UPCOMING EVENTS */
+
+  #upcoming-events {
+    max-height: 600px;
+    overflow-y: scroll;
+  }
+
   /* LINKS/BIRTHDAYS */
   #links,
   #birthdays {

--- a/com/static/com/css/news-list.scss
+++ b/com/static/com/css/news-list.scss
@@ -56,6 +56,13 @@
   #upcoming-events {
     max-height: 600px;
     overflow-y: scroll;
+
+    #load-more-news-button {
+      text-align: center;
+      button {
+        width: 150px;
+      }
+    }
   }
 
   /* LINKS/BIRTHDAYS */

--- a/com/templates/com/macros.jinja
+++ b/com/templates/com/macros.jinja
@@ -6,15 +6,41 @@
     the given `alpineState` variable.
     This state is a `AlertState`, as defined in `moderation-alert-index.ts`
 
-    Example :
+    This comes in three flavours :
+    - You can pass the `News` object itself to the macro.
+      In this case, if `request.user` can moderate news,
+      it will perform an additional db query to know if it is a recurring event.
+    - You can also give only the news id.
+      In this case, a server request will be issued to know
+      if it is a recurring event.
+    - Finally, you can pass the name of an alpine variable, which value is the id.
+      In this case, a server request will be issued to know
+      if it is a recurring event.
+
+    Example with full `News` object :
     ```jinja
     <div x-data="{state: AlertState.PENDING}">
       {{ news_moderation_alert(news, user, "state") }}
     </div>
     ```
+    With an id :
+    ```jinja
+    <div x-data="{state: AlertState.PENDING}">
+      {{ news_moderation_alert(news.id, user, "state") }}
+    </div>
+    ```
+    An with an alpine variable
+    ```jinja
+    <div x-data="{state: AlertState.PENDING, newsId: {{ news.id }}">
+      {{ news_moderation_alert("newsId", user, "state") }}
+    </div>
+    ```
+
 
     Args:
-        news: The `News` object to which this alert is related
+        news: (News | int | string)
+          Either the `News` object to which this alert is related,
+          or its id, or the name of an Alpine which value is its id
         user: The request.user
         alpineState: An alpine variable name
 
@@ -23,7 +49,13 @@
         in your template.
     #}
   <div
-    x-data="moderationAlert({{ news.id }})"
+    {% if news is integer or news is string %}
+      x-data="moderationAlert({{ news }})"
+    {% else %}
+      x-data="moderationAlert({{ news.id }})"
+    {% endif %}
+    {# the news-moderated is received when a moderation alert is deleted or moderated #}
+    @news-moderated.window="dispatchModeration($event)"
     {% if alpineState %}
       x-modelable="{{ alpineState }}"
       x-model="state"
@@ -49,18 +81,31 @@
             but it will be executed only for admin users, and only one time
             (if they do their job and moderated news as soon as they see them),
             so it's still reasonable #}
-            {% set nb_event=news.dates.count() %}
-            {% if nb_event > 1 %}
-              <br>
-              <strong>{% trans %}Weekly event{% endtrans %}</strong>
-              <p>
-                {% trans trimmed nb=nb_event %}
-                  This event will take place every week for {{ nb }} weeks.
-                  If you moderate or delete this event,
-                  it will also be moderated (or deleted) for the following weeks.
-                {% endtrans %}
-              </p>
-            {% endif %}
+            <div
+              {% if news is integer or news is string %}
+                x-data="{ nbEvents: nbModerated() }"
+              {% else %}
+                x-data="{ nbEvents: {{ news.dates.count() }} }"
+              {% endif %}
+            >
+              <template x-if="nbEvents > 1">
+                <div>
+                  <br>
+                  <strong>{% trans %}Weekly event{% endtrans %}</strong>
+                  {# hybrid translation : the text is translated server-side,
+                  but the interpolation of `nbEvents` is done client-side. #}
+                  <p
+                    x-text="interpolate('
+                            {%- trans trimmed -%}
+                              This event will take place every week for %s weeks.
+                              If you moderate or delete this event,
+                              it will also be moderated (or deleted) for the following weeks.
+                            {%- endtrans -%}
+                            ', [nbEvents])"
+                  ></p>
+                </div>
+              </template>
+            </div>
           {% endif %}
         </div>
         {% if user.has_perm("com.moderate_news") %}

--- a/com/templates/com/macros.jinja
+++ b/com/templates/com/macros.jinja
@@ -83,7 +83,8 @@
             so it's still reasonable #}
             <div
               {% if news is integer or news is string %}
-                x-data="{ nbEvents: nbModerated() }"
+                x-data="{ nbEvents: 0 }"
+                x-init="nbEvents = await nbToModerate()"
               {% else %}
                 x-data="{ nbEvents: {{ news.dates.count() }} }"
               {% endif %}

--- a/com/templates/com/macros.jinja
+++ b/com/templates/com/macros.jinja
@@ -92,17 +92,7 @@
                 <div>
                   <br>
                   <strong>{% trans %}Weekly event{% endtrans %}</strong>
-                  {# hybrid translation : the text is translated server-side,
-                  but the interpolation of `nbEvents` is done client-side. #}
-                  <p
-                    x-text="interpolate('
-                            {%- trans trimmed -%}
-                              This event will take place every week for %s weeks.
-                              If you moderate or delete this event,
-                              it will also be moderated (or deleted) for the following weeks.
-                            {%- endtrans -%}
-                            ', [nbEvents])"
-                  ></p>
+                  <p x-text="weeklyEventWarningMessage(nbEvents)"></p>
                 </div>
               </template>
             </div>

--- a/com/templates/com/news_list.jinja
+++ b/com/templates/com/news_list.jinja
@@ -16,6 +16,7 @@
 {% block additional_js %}
   <script type="module" src={{ static("bundled/com/components/ics-calendar-index.ts") }}></script>
   <script type="module" src={{ static("bundled/com/components/moderation-alert-index.ts") }}></script>
+  <script type="module" src={{ static("bundled/com/components/upcoming-news-loader-index.ts") }}></script>
 {% endblock %}
 
 {% block content %}
@@ -38,69 +39,140 @@
         <br>
       {% endif %}
       <section id="upcoming-events">
-        {% for day, dates_group in news_dates %}
-          <div class="news_events_group">
-            <div class="news_events_group_date">
-              <div>
-                <div>{{ day|date('D') }}</div>
-                <div class="day">{{ day|date('d') }}</div>
-                <div>{{ day|date('b') }}</div>
-              </div>
-            </div>
-            <div class="news_events_group_items">
-              {% for date in dates_group %}
-                <article
-                  class="news_event"
-                  {%- if not date.news.is_moderated -%}
-                    x-data="{newsState: AlertState.PENDING}"
-                  {%- endif -%}
-                >
-                  {% if not date.news.is_moderated %}
-                  {# if a non moderated news is in the object list,
-                  the logged user is either an admin or the news author #}
-                    {{ news_moderation_alert(date.news, user, "newsState") }}
-                  {% endif %}
-                  <div
-                    {% if not date.news.is_moderated -%}
-                      x-show="newsState !== AlertState.DELETED"
-                    {%- endif -%}
-                  >
-                    <header class="row gap">
-                      {% if date.news.club.logo %}
-                        <img src="{{ date.news.club.logo.url }}" alt="{{ date.news.club }}"/>
-                      {% else %}
-                        <img src="{{ static("com/img/news.png") }}" alt="{{ date.news.club }}"/>
-                      {% endif %}
-                      <div class="header_content">
-                        <h4>
-                          <a href="{{ url('com:news_detail', news_id=date.news_id) }}">
-                            {{ date.news.title }}
-                          </a>
-                        </h4>
-                        <a href="{{ date.news.club.get_absolute_url() }}">{{ date.news.club }}</a>
-                        <div class="news_date">
-                          <time datetime="{{ date.start_date.isoformat(timespec="seconds") }}">
-                            {{ date.start_date|localtime|time(DATETIME_FORMAT) }}
-                          </time> -
-                          <time datetime="{{ date.end_date.isoformat(timespec="seconds") }}">
-                            {{ date.end_date|localtime|time(DATETIME_FORMAT) }}
-                          </time>
-                        </div>
-                      </div>
-                    </header>
-                    <div class="news_content markdown">
-                      {{ date.news.summary|markdown }}
-                    </div>
-                  </div>
-                </article>
-              {% endfor %}
-            </div>
-          </div>
-        {% else %}
+        {% if not news_dates %}
           <div class="news_empty">
             <em>{% trans %}Nothing to come...{% endtrans %}</em>
           </div>
-        {% endfor %}
+        {% else %}
+          {% for day, dates_group in news_dates %}
+            <div class="news_events_group">
+              <div class="news_events_group_date">
+                <div>
+                  <div>{{ day|date('D') }}</div>
+                  <div class="day">{{ day|date('d') }}</div>
+                  <div>{{ day|date('b') }}</div>
+                </div>
+              </div>
+              <div class="news_events_group_items">
+                {% for date in dates_group %}
+                  <article
+                    class="news_event"
+                    {%- if not date.news.is_moderated -%}
+                      x-data="{newsState: AlertState.PENDING}"
+                    {%- endif -%}
+                  >
+                    {% if not date.news.is_moderated %}
+                      {# if a non moderated news is in the object list,
+                      the logged user is either an admin or the news author #}
+                      {{ news_moderation_alert(date.news, user, "newsState") }}
+                    {% endif %}
+                    <div
+                      {% if not date.news.is_moderated -%}
+                        x-show="newsState !== AlertState.DELETED"
+                      {%- endif -%}
+                    >
+                      <header class="row gap">
+                        {% if date.news.club.logo %}
+                          <img src="{{ date.news.club.logo.url }}" alt="{{ date.news.club }}"/>
+                        {% else %}
+                          <img src="{{ static("com/img/news.png") }}" alt="{{ date.news.club }}"/>
+                        {% endif %}
+                        <div class="header_content">
+                          <h4>
+                            <a href="{{ url('com:news_detail', news_id=date.news_id) }}">
+                              {{ date.news.title }}
+                            </a>
+                          </h4>
+                          <a href="{{ date.news.club.get_absolute_url() }}">{{ date.news.club }}</a>
+                          <div class="news_date">
+                            <time datetime="{{ date.start_date.isoformat(timespec="seconds") }}">
+                              {{ date.start_date|localtime|time(DATETIME_FORMAT) }}
+                            </time> -
+                            <time datetime="{{ date.end_date.isoformat(timespec="seconds") }}">
+                              {{ date.end_date|localtime|time(DATETIME_FORMAT) }}
+                            </time>
+                          </div>
+                        </div>
+                      </header>
+                      <div class="news_content markdown">
+                        {{ date.news.summary|markdown }}
+                      </div>
+                    </div>
+                  </article>
+                {% endfor %}
+              </div>
+            </div>
+          {% endfor %}
+          <div x-data="upcomingNewsLoader(new Date('{{ last_day + timedelta(days=1) }}'))">
+            <template x-for="newsList in Object.values(groupedDates())">
+              <div class="news_events_group">
+                <div class="news_events_group_date">
+                  <div x-data="{day: newsList[0].start_date}">
+                    <div x-text="day.toLocaleString('{{ get_language() }}', { weekday: 'short' }).substring(0, 3)"></div>
+                    <div
+                      class="day"
+                      x-text="day.toLocaleString('{{ get_language() }}', { day: 'numeric' })"
+                    ></div>
+                    <div x-text="day.toLocaleString('{{ get_language() }}', { month: 'short' }).substring(0, 3)"></div>
+                  </div>
+                </div>
+                <div class="news_events_group_items">
+                  <template x-for="newsDate in newsList" :key="newsDate.id">
+                    <article
+                      class="news_event"
+                      x-data="{ newsState: newsDate.news.is_moderated ? AlertState.MODERATED : AlertState.PENDING }"
+                    >
+                      <template x-if="!newsDate.news.is_moderated">
+                        {{ news_moderation_alert("newsDate.news.id", user, "newsState") }}
+                      </template>
+                      <div x-show="newsState !== AlertState.DELETED">
+                        <header class="row gap">
+                          <img
+                            :src="newsDate.news.club.logo || '{{ static("com/img/news.png") }}'"
+                            :alt="newsDate.news.club.name"
+                          />
+                          <div class="header_content">
+                            <h4>
+                              <a :href="newsDate.news.url" x-text="newsDate.news.title"></a>
+                            </h4>
+                            <a :href="newsDate.news.club.url" x-text="newsDate.news.club.name"></a>
+                            <div class="news_date">
+                              <time
+                                :datetime="newsDate.start_date.toISOString()"
+                                x-text="`${newsDate.start_date.getHours()}:${newsDate.start_date.getMinutes()}`"
+                              ></time> -
+                              <time
+                                :datetime="newsDate.end_date.toISOString()"
+                                x-text="`${newsDate.end_date.getHours()}:${newsDate.end_date.getMinutes()}`"
+                              ></time>
+                            </div>
+                          </div>
+                        </header>
+                        {# The API returns a summary in html.
+                           It's generated from our markdown subset, so it should be safe #}
+                        <div class="news_content markdown" x-html="newsDate.news.summary"></div>
+                      </div>
+                    </article>
+                  </template>
+                </div>
+              </div>
+            </template>
+
+            <div id="load-more-news-button" :aria-busy="loading">
+              <button class="btn btn-grey" x-show="!loading && hasNext" @click="loadMore()">
+                {% trans %}See more{% endtrans %} &nbsp;<i class="fa fa-arrow-down"></i>
+              </button>
+              <p x-show="!loading && !hasNext">
+                <em>
+                  {% trans trimmed %}
+                    It was too short.
+                    You already reached the end of the upcoming events list.
+                  {% endtrans %}
+                </em>
+              </p>
+            </div>
+          </div>
+        {% endif %}
       </section>
 
       <h3>

--- a/com/templates/com/news_list.jinja
+++ b/com/templates/com/news_list.jinja
@@ -37,69 +37,71 @@
         </a>
         <br>
       {% endif %}
-      {% for day, dates_group in news_dates %}
-        <div class="news_events_group">
-          <div class="news_events_group_date">
-            <div>
-              <div>{{ day|date('D') }}</div>
-              <div class="day">{{ day|date('d') }}</div>
-              <div>{{ day|date('b') }}</div>
+      <section id="upcoming-events">
+        {% for day, dates_group in news_dates %}
+          <div class="news_events_group">
+            <div class="news_events_group_date">
+              <div>
+                <div>{{ day|date('D') }}</div>
+                <div class="day">{{ day|date('d') }}</div>
+                <div>{{ day|date('b') }}</div>
+              </div>
             </div>
-          </div>
-          <div class="news_events_group_items">
-            {% for date in dates_group %}
-              <article
-                class="news_event"
-                {%- if not date.news.is_moderated -%}
-                  x-data="{newsState: AlertState.PENDING}"
-                {%- endif -%}
-              >
-                {% if not date.news.is_moderated %}
-                  {# if a non moderated news is in the object list,
-                  the logged user is either an admin or the news author #}
-                  {{ news_moderation_alert(date.news, user, "newsState") }}
-                {% endif %}
-                <div
-                  {% if not date.news.is_moderated -%}
-                    x-show="newsState !== AlertState.DELETED"
+            <div class="news_events_group_items">
+              {% for date in dates_group %}
+                <article
+                  class="news_event"
+                  {%- if not date.news.is_moderated -%}
+                    x-data="{newsState: AlertState.PENDING}"
                   {%- endif -%}
                 >
-                  <header class="row gap">
-                    {% if date.news.club.logo %}
-                      <img src="{{ date.news.club.logo.url }}" alt="{{ date.news.club }}"/>
-                    {% else %}
-                      <img src="{{ static("com/img/news.png") }}" alt="{{ date.news.club }}"/>
-                    {% endif %}
-                    <div class="header_content">
-                      <h4>
-                        <a href="{{ url('com:news_detail', news_id=date.news_id) }}">
-                          {{ date.news.title }}
-                        </a>
-                      </h4>
-                      <a href="{{ date.news.club.get_absolute_url() }}">{{ date.news.club }}</a>
-                      <div class="news_date">
-                        <time datetime="{{ date.start_date.isoformat(timespec="seconds") }}">
-                          {{ date.start_date|localtime|time(DATETIME_FORMAT) }}
-                        </time> -
-                        <time datetime="{{ date.end_date.isoformat(timespec="seconds") }}">
-                          {{ date.end_date|localtime|time(DATETIME_FORMAT) }}
-                        </time>
+                  {% if not date.news.is_moderated %}
+                  {# if a non moderated news is in the object list,
+                  the logged user is either an admin or the news author #}
+                    {{ news_moderation_alert(date.news, user, "newsState") }}
+                  {% endif %}
+                  <div
+                    {% if not date.news.is_moderated -%}
+                      x-show="newsState !== AlertState.DELETED"
+                    {%- endif -%}
+                  >
+                    <header class="row gap">
+                      {% if date.news.club.logo %}
+                        <img src="{{ date.news.club.logo.url }}" alt="{{ date.news.club }}"/>
+                      {% else %}
+                        <img src="{{ static("com/img/news.png") }}" alt="{{ date.news.club }}"/>
+                      {% endif %}
+                      <div class="header_content">
+                        <h4>
+                          <a href="{{ url('com:news_detail', news_id=date.news_id) }}">
+                            {{ date.news.title }}
+                          </a>
+                        </h4>
+                        <a href="{{ date.news.club.get_absolute_url() }}">{{ date.news.club }}</a>
+                        <div class="news_date">
+                          <time datetime="{{ date.start_date.isoformat(timespec="seconds") }}">
+                            {{ date.start_date|localtime|time(DATETIME_FORMAT) }}
+                          </time> -
+                          <time datetime="{{ date.end_date.isoformat(timespec="seconds") }}">
+                            {{ date.end_date|localtime|time(DATETIME_FORMAT) }}
+                          </time>
+                        </div>
                       </div>
+                    </header>
+                    <div class="news_content markdown">
+                      {{ date.news.summary|markdown }}
                     </div>
-                  </header>
-                  <div class="news_content markdown">
-                    {{ date.news.summary|markdown }}
                   </div>
-                </div>
-              </article>
-            {% endfor %}
+                </article>
+              {% endfor %}
+            </div>
           </div>
-        </div>
-      {% else %}
-        <div class="news_empty">
-          <em>{% trans %}Nothing to come...{% endtrans %}</em>
-        </div>
-      {% endfor %}
+        {% else %}
+          <div class="news_empty">
+            <em>{% trans %}Nothing to come...{% endtrans %}</em>
+          </div>
+        {% endfor %}
+      </section>
 
       <h3>
         {% trans %}All coming events{% endtrans %}

--- a/core/management/commands/populate.py
+++ b/core/management/commands/populate.py
@@ -169,7 +169,7 @@ class Command(BaseCommand):
         Weekmail().save()
 
         # Here we add a lot of test datas, that are not necessary for the Sith, but that provide a basic development environment
-        self.now = timezone.now().replace(hour=12)
+        self.now = timezone.now().replace(hour=12, second=0)
 
         skia = User.objects.create_user(
             username="skia",
@@ -681,7 +681,7 @@ Welcome to the wiki page!
         friday = self.now
         while friday.weekday() != 4:
             friday += timedelta(hours=6)
-        friday.replace(hour=20, minute=0, second=0)
+        friday.replace(hour=20, minute=0)
         # Event
         news_dates = []
         n = News.objects.create(

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 19:12+0100\n"
+"POT-Creation-Date: 2025-02-25 11:04+0100\n"
 "PO-Revision-Date: 2016-07-18\n"
 "Last-Translator: Maréchal <thomas.girod@utbm.fr\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -1426,17 +1426,6 @@ msgstr ""
 "Elle sera cachée pour les autres utilisateurs tant qu'elle ne sera pas "
 "modérée."
 
-#: com/templates/com/macros.jinja
-#, python-format
-msgid ""
-"This event will take place every week for %%s weeks. If you moderate or "
-"delete this event, it will also be moderated (or deleted) for the following "
-"weeks."
-msgstr ""
-"Cet événement se déroulera chaque semaine pendant %%s semaines. Si vous "
-"modérez ou supprimez cet événement, il sera également modéré (ou supprimé) "
-"pour les semaines suivantes."
-
 #: com/templates/com/macros.jinja com/templates/com/mailing_admin.jinja
 #: com/templates/com/news_admin_list.jinja com/templates/com/news_detail.jinja
 #: core/templates/core/file_detail.jinja
@@ -1584,8 +1573,7 @@ msgstr "Voir plus"
 
 #: com/templates/com/news_list.jinja
 msgid ""
-"It was too short. You already reached the end of the upcoming events "
-"list."
+"It was too short. You already reached the end of the upcoming events list."
 msgstr ""
 "C'était trop court. Vous êtes déjà arrivés à la fin de la liste des "
 "événements à venir."
@@ -6043,3 +6031,13 @@ msgstr "Vous ne pouvez plus écrire de commentaires, la date est passée."
 #, python-format
 msgid "Maximum characters: %(max_length)s"
 msgstr "Nombre de caractères max: %(max_length)s"
+
+#, python-format
+#~ msgid ""
+#~ "This event will take place every week for %%s weeks. If you moderate or "
+#~ "delete this event, it will also be moderated (or deleted) for the "
+#~ "following weeks."
+#~ msgstr ""
+#~ "Cet événement se déroulera chaque semaine pendant %%s semaines. Si vous "
+#~ "modérez ou supprimez cet événement, il sera également modéré (ou "
+#~ "supprimé) pour les semaines suivantes."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-18 15:03+0100\n"
+"POT-Creation-Date: 2025-02-19 19:12+0100\n"
 "PO-Revision-Date: 2016-07-18\n"
 "Last-Translator: Maréchal <thomas.girod@utbm.fr\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -1429,11 +1429,11 @@ msgstr ""
 #: com/templates/com/macros.jinja
 #, python-format
 msgid ""
-"This event will take place every week for %(nb)s weeks. If you moderate or "
+"This event will take place every week for %%s weeks. If you moderate or "
 "delete this event, it will also be moderated (or deleted) for the following "
 "weeks."
 msgstr ""
-"Cet événement se déroulera chaque semaine pendant %(nb)s semaines. Si vous "
+"Cet événement se déroulera chaque semaine pendant %%s semaines. Si vous "
 "modérez ou supprimez cet événement, il sera également modéré (ou supprimé) "
 "pour les semaines suivantes."
 
@@ -1577,6 +1577,18 @@ msgstr "Administrer les news"
 #: com/templates/com/news_list.jinja
 msgid "Nothing to come..."
 msgstr "Rien à venir..."
+
+#: com/templates/com/news_list.jinja
+msgid "See more"
+msgstr "Voir plus"
+
+#: com/templates/com/news_list.jinja
+msgid ""
+"It was too short. You already reached the end of the upcoming events "
+"list."
+msgstr ""
+"C'était trop court. Vous êtes déjà arrivés à la fin de la liste des "
+"événements à venir."
 
 #: com/templates/com/news_list.jinja
 msgid "All coming events"

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-08 12:23+0100\n"
+"POT-Creation-Date: 2025-02-25 11:05+0100\n"
 "PO-Revision-Date: 2024-09-17 11:54+0200\n"
 "Last-Translator: Sli <antoine@bartuccio.fr>\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -20,6 +20,17 @@ msgstr ""
 #: com/static/bundled/com/components/ics-calendar-index.ts
 msgid "More info"
 msgstr "Plus d'informations"
+
+#: com/static/bundled/com/components/moderation-alert-index.ts
+#, javascript-format
+msgid ""
+"This event will take place every week for %s weeks. If you moderate or "
+"delete this event, it will also be moderated (or deleted) for the following "
+"weeks."
+msgstr ""
+"Cet événement se déroulera chaque semaine pendant %s semaines. Si vous "
+"modérez ou supprimez cet événement, il sera également modéré (ou supprimé) "
+"pour les semaines suivantes."
 
 #: core/static/bundled/core/components/ajax-select-base.ts
 msgid "Remove"
@@ -125,10 +136,6 @@ msgstr "Montrer plus"
 msgid "family_tree.%(extension)s"
 msgstr "arbre_genealogique.%(extension)s"
 
-#: core/static/bundled/user/pictures-index.js
-msgid "pictures.%(extension)s"
-msgstr "photos.%(extension)s"
-
 #: core/static/user/js/user_edit.js
 #, javascript-format
 msgid "captured.%s"
@@ -186,6 +193,10 @@ msgstr "La réorganisation des types de produit a échoué avec le code : %d"
 #: eboutic/static/eboutic/js/makecommand.js
 msgid "Incorrect value"
 msgstr "Valeur incorrecte"
+
+#: sas/static/bundled/sas/pictures-download-index.ts
+msgid "pictures.%(extension)s"
+msgstr "photos.%(extension)s"
 
 #: sas/static/bundled/sas/viewer-index.ts
 msgid "Couldn't moderate picture"

--- a/sith/settings.py
+++ b/sith/settings.py
@@ -171,6 +171,7 @@ TEMPLATES = [
                 "timezone": "django.utils.timezone",
                 "get_sith": "com.views.sith",
                 "get_language": "django.utils.translation.get_language",
+                "timedelta": "datetime.timedelta",
             },
             "bytecode_cache": {
                 "name": "default",


### PR DESCRIPTION
Sur la page d'accueil, on ne limite plus le nombre de nouvelles affichées, mais on affiche les prochains jours où il se passe quelque chose (même s'ils arrivent dans longtemps).

Quand le section prend trop de place, on la rend scrollable.

Et quand on arrive en bas et qu'il y a plus à charger, on met un bouton "voir plus" qui permet de charger les jours d'après.