### PR TITLE
Give the student role when creating a new user subscription

### DIFF
--- a/subscription/forms.py
+++ b/subscription/forms.py
@@ -100,6 +100,13 @@ class SubscriptionNewUserForm(SubscriptionForm):
             email=self.cleaned_data.get("email"),
             date_of_birth=self.cleaned_data.get("date_of_birth"),
         )
+        if self.cleaned_data.get("subscription_type") in [
+            "un-semestre",
+            "deux-semestres",
+            "cursus-tronc-commun",
+            "cursus-branche",
+        ]:
+            member.role = "STUDENT"
         member.generate_username()
         member.set_password(secrets.token_urlsafe(nbytes=10))
         self.instance.member = member

--- a/subscription/tests/test_new_susbcription.py
+++ b/subscription/tests/test_new_susbcription.py
@@ -91,6 +91,28 @@ def test_form_new_user(settings: SettingsWrapper):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
+    "subscription_type",
+    ["un-semestre", "deux-semestres", "cursus-tronc-commun", "cursus-branche"],
+)
+def test_form_set_new_user_as_student(settings: SettingsWrapper, subscription_type):
+    """Test that new users have the student role by default."""
+    data = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "jdoe@utbm.fr",
+        "date_of_birth": localdate() - relativedelta(years=18),
+        "subscription_type": subscription_type,
+        "location": settings.SITH_SUBSCRIPTION_LOCATIONS[0][0],
+        "payment_method": settings.SITH_SUBSCRIPTION_PAYMENT_METHOD[0][0],
+    }
+    form = SubscriptionNewUserForm(data)
+    assert form.is_valid()
+    form.clean()
+    assert form.instance.member.role == "STUDENT"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
     ("user_factory", "status_code"),
     [
         (lambda: baker.make(User, is_superuser=True), 200),


### PR DESCRIPTION
Quand une cotisation est créée pour un nouvel utilisateur, on donne le statut "étudiant" au nouvel utilisateur, s'il s'agit d'une cotisation cursus ou d'une cotisation un semestre ou deux semestres.