### PR TITLE
Fix sales display

### DIFF
--- a/counter/models.py
+++ b/counter/models.py
@@ -847,11 +847,10 @@ class Selling(models.Model):
         verbose_name = _("selling")
 
     def __str__(self):
-        return "Selling: %d x %s (%f) for %s" % (
-            self.quantity,
-            self.label,
-            self.quantity * self.unit_price,
-            self.customer.user.get_display_name(),
+        return (
+            f"Selling: {self.quantity} x {self.label} "
+            f"({self.quantity * self.unit_price} €) "
+            f"for {self.customer.user.get_display_name()}"
         )
 
     def save(self, *args, allow_negative=False, **kwargs):


### PR DESCRIPTION
Répare l'affichage avec trop de chiffres après la virgule quand on annule une vente : 
![image](https://github.com/user-attachments/assets/a47757d4-6197-470b-856e-3c71e2600f00)

Après réparation, ça donne ça : 
![image](https://github.com/user-attachments/assets/d996577f-9e22-4c87-abc9-1b5ab9531249)



