### PR TITLE
Fix some deprecations

### DIFF
--- a/accounting/tests.py
+++ b/accounting/tests.py
@@ -32,7 +32,7 @@ class TestRefoundAccount(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.skia = User.objects.get(username="skia")
-        # reffil skia's account
+        # refill skia's account
         cls.skia.customer.amount = 800
         cls.skia.customer.save()
         cls.refound_account_url = reverse("accounting:refound_account")

--- a/com/schemas.py
+++ b/com/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from ninja import FilterSchema, ModelSchema
 from ninja_extra import service_resolver
-from ninja_extra.controllers import RouteContext
+from ninja_extra.context import RouteContext
 from pydantic import Field
 
 from club.schemas import ClubProfileSchema

--- a/core/auth/mixins.py
+++ b/core/auth/mixins.py
@@ -169,10 +169,9 @@ class CanCreateMixin(View):
         super().__init__(*args, **kwargs)
 
     def dispatch(self, request, *arg, **kwargs):
-        res = super().dispatch(request, *arg, **kwargs)
         if not request.user.is_authenticated:
             raise PermissionDenied
-        return res
+        return super().dispatch(request, *arg, **kwargs)
 
     def form_valid(self, form):
         obj = form.instance

--- a/core/management/commands/populate.py
+++ b/core/management/commands/populate.py
@@ -919,6 +919,7 @@ Welcome to the wiki page!
                         "view_album",
                         "view_peoplepicturerelation",
                         "add_peoplepicturerelation",
+                        "add_page",
                     ]
                 )
             )

--- a/core/static/bundled/utils/api.ts
+++ b/core/static/bundled/utils/api.ts
@@ -30,7 +30,7 @@ export const paginated = async <T>(
   endpoint: PaginatedEndpoint<T>,
   options?: PaginatedRequest,
 ): Promise<T[]> => {
-  const maxPerPage = 199;
+  const maxPerPage = 200;
   const queryParams = options ?? ({} as PaginatedRequest);
   queryParams.query = queryParams.query ?? {};
   queryParams.query.page_size = maxPerPage;

--- a/core/static/core/header.scss
+++ b/core/static/core/header.scss
@@ -251,21 +251,31 @@ $hovered-red-text-color: #ff4d4d;
               justify-content: flex-start;
             }
 
-            >a {
+            a, button {
+              font-size: 100%;
+              margin: 0;
               text-align: right;
               color: $text-color;
 
               &:hover {
                 color: $hovered-text-color;
               }
+            }
 
-              &:last-child {
-                color: $red-text-color;
+            form#logout-form {
+              margin: 0;
+              display: inline;
+            }
+            #logout-form button {
+              color: $red-text-color;
 
-                &:hover {
-                  color: $hovered-red-text-color;
-                }
+              &:hover {
+                color: $hovered-red-text-color;
               }
+              background: none;
+              border: none;
+              cursor: pointer;
+              padding: 0;
             }
           }
         }

--- a/core/templates/core/base.jinja
+++ b/core/templates/core/base.jinja
@@ -84,18 +84,18 @@
       </ul>
 
       <div id="content">
-        {% block tabs %}
+        {%- block tabs -%}
           {% include "core/base/tabs.jinja" %}
-        {% endblock %}
+        {%- endblock -%}
 
-        {% block errors%}
+        {%- block errors -%}
           {% if error %}
             {{ error }}
           {% endif %}
-        {% endblock %}
+        {%- endblock -%}
 
-        {% block content %}
-        {% endblock %}
+        {%- block content -%}
+        {%- endblock -%}
       </div>
     </div>
 

--- a/core/templates/core/base/header.jinja
+++ b/core/templates/core/base/header.jinja
@@ -59,7 +59,10 @@
             </div>
             <div class="links">
               <a href="{{ url('core:user_tools') }}">{% trans %}Tools{% endtrans %}</a>
-              <a href="{{ url('core:logout') }}">{% trans %}Logout{% endtrans %}</a>
+              <form id="logout-form" method="post" action="{{ url("core:logout") }}">
+                {% csrf_token %}
+                <button type="submit">{% trans %}Logout{% endtrans %}</button>
+              </form>
             </div>
           </div>
           <a

--- a/core/templates/core/page.jinja
+++ b/core/templates/core/page.jinja
@@ -12,16 +12,15 @@
   {% endif %}
 {% endblock %}
 
-{% macro print_page_name(page) %}
-  {% if page %}
+{%- macro print_page_name(page) -%}
+  {%- if page -%}
     {{ print_page_name(page.parent) }} >
     <a href="{{ url('core:page', page_name=page.get_full_name()) }}">{{ page.get_display_name() }}</a>
-  {% endif %}
-{% endmacro %}
+  {%- endif -%}
+{%- endmacro -%}
 
 {% block content %}
   {{ print_page_name(page) }}
-
   <div class="tool_bar">
     <div class="tools">
       {% if page %}

--- a/core/tests/test_user.py
+++ b/core/tests/test_user.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import pytest
 from django.conf import settings
+from django.contrib import auth
 from django.core.management import call_command
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -219,3 +220,12 @@ def test_user_update_groups(client: Client):
         manageable_groups[1],
         *hidden_groups[:3],
     }
+
+
+@pytest.mark.django_db
+def test_logout(client: Client):
+    user = baker.make(User)
+    client.force_login(user)
+    res = client.post(reverse("core:logout"))
+    assertRedirects(res, reverse("core:login"))
+    assert auth.get_user(client).is_anonymous

--- a/core/views/files.py
+++ b/core/views/files.py
@@ -403,6 +403,7 @@ class FileModerationView(AllowFragment, ListView):
     model = SithFile
     template_name = "core/file_moderation.jinja"
     queryset = SithFile.objects.filter(is_moderated=False, is_in_sas=False)
+    ordering = "id"
     paginate_by = 100
 
     def dispatch(self, request: HttpRequest, *args, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ tests = [
     "pytest-cov<7.0.0,>=6.0.0",
     "pytest-django<5.0.0,>=4.10.0",
     "model-bakery<2.0.0,>=1.20.4",
+    "beautifulsoup4>=4.13.3,<5",
+    "lxml>=5.3.1,<6",
 ]
 docs = [
     "mkdocs<2.0.0,>=1.6.1",

--- a/subscription/forms.py
+++ b/subscription/forms.py
@@ -94,6 +94,13 @@ class SubscriptionNewUserForm(SubscriptionForm):
         return email
 
     def clean(self) -> dict[str, Any]:
+        """Initialize the [User][core.models.User] linked to this subscription.
+
+        Warning:
+            The `User` is initialized, but not saved.
+            Don't use it for operations that expect
+            a persisted object.
+        """
         member = User(
             first_name=self.cleaned_data.get("first_name"),
             last_name=self.cleaned_data.get("last_name"),

--- a/subscription/models.py
+++ b/subscription/models.py
@@ -92,9 +92,13 @@ class Subscription(models.Model):
         self.member.make_home()
 
     def get_absolute_url(self):
-        return reverse("core:user_edit", kwargs={"user_id": self.member.pk})
+        return reverse("core:user_edit", kwargs={"user_id": self.member_id})
 
     def clean(self):
+        if self.member._state.adding:
+            # if the user is being created, then it makes no sense
+            # to check if the user is already subscribed
+            return
         today = localdate()
         threshold = timedelta(weeks=settings.SITH_SUBSCRIPTION_END)
         # a user may subscribe if :

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/3c/adaf39ce1fb4afdd21b611e3d530b183bb7759c9b673d60db0e347fd4439/beautifulsoup4-4.13.3.tar.gz", hash = "sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b", size = 619516 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/49/6abb616eb3cbab6a7cca303dc02fdf3836de2e0b834bf966a7f5271a34d8/beautifulsoup4-4.13.3-py3-none-any.whl", hash = "sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16", size = 186015 },
+]
+
+[[package]]
 name = "bracex"
 version = "2.5.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -753,6 +766,48 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/5a/eb5b62641df0459a3291fc206cf5bd669c0feed7814dded8edef4ade8512/libsass-0.23.0-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4a218406d605f325d234e4678bd57126a66a88841cb95bee2caeafdc6f138306", size = 9444543 },
     { url = "https://files.pythonhosted.org/packages/e5/fc/275783f5120970d859ae37d04b6a60c13bdec2aa4294b9dfa8a37b5c2513/libsass-0.23.0-cp38-abi3-win32.whl", hash = "sha256:31e86d92a5c7a551df844b72d83fc2b5e50abc6fbbb31e296f7bebd6489ed1b4", size = 775481 },
     { url = "https://files.pythonhosted.org/packages/ef/20/caf3c7cf2432d85263119798c45221ddf67bdd7dae8f626d14ff8db04040/libsass-0.23.0-cp38-abi3-win_amd64.whl", hash = "sha256:a2ec85d819f353cbe807432d7275d653710d12b08ec7ef61c124a580a8352f3c", size = 872914 },
+]
+
+[[package]]
+name = "lxml"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/f6/c15ca8e5646e937c148e147244817672cf920b56ac0bf2cc1512ae674be8/lxml-5.3.1.tar.gz", hash = "sha256:106b7b5d2977b339f1e97efe2778e2ab20e99994cbb0ec5e55771ed0795920c8", size = 3678591 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/f4/5121aa9ee8e09b8b8a28cf3709552efe3d206ca51a20d6fa471b60bb3447/lxml-5.3.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:e69add9b6b7b08c60d7ff0152c7c9a6c45b4a71a919be5abde6f98f1ea16421c", size = 8191889 },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/8e9aa01edddc74878f4aea85aa9ab64372f46aa804d1c36dda861bf9eabf/lxml-5.3.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:4e52e1b148867b01c05e21837586ee307a01e793b94072d7c7b91d2c2da02ffe", size = 4450685 },
+    { url = "https://files.pythonhosted.org/packages/b2/b3/ea40a5c98619fbd7e9349df7007994506d396b97620ced34e4e5053d3734/lxml-5.3.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4b382e0e636ed54cd278791d93fe2c4f370772743f02bcbe431a160089025c9", size = 5051722 },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/375418be35f8a695cadfe7e7412f16520e62e24952ed93c64c9554755464/lxml-5.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2e49dc23a10a1296b04ca9db200c44d3eb32c8d8ec532e8c1fd24792276522a", size = 4786661 },
+    { url = "https://files.pythonhosted.org/packages/79/7c/d258eaaa9560f6664f9b426a5165103015bee6512d8931e17342278bad0a/lxml-5.3.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4399b4226c4785575fb20998dc571bc48125dc92c367ce2602d0d70e0c455eb0", size = 5311766 },
+    { url = "https://files.pythonhosted.org/packages/03/bc/a041415be4135a1b3fdf017a5d873244cc16689456166fbdec4b27fba153/lxml-5.3.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5412500e0dc5481b1ee9cf6b38bb3b473f6e411eb62b83dc9b62699c3b7b79f7", size = 4836014 },
+    { url = "https://files.pythonhosted.org/packages/32/88/047f24967d5e3fc97848ea2c207eeef0f16239cdc47368c8b95a8dc93a33/lxml-5.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c93ed3c998ea8472be98fb55aed65b5198740bfceaec07b2eba551e55b7b9ae", size = 4961064 },
+    { url = "https://files.pythonhosted.org/packages/3d/b5/ecf5a20937ecd21af02c5374020f4e3a3538e10a32379a7553fca3d77094/lxml-5.3.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63d57fc94eb0bbb4735e45517afc21ef262991d8758a8f2f05dd6e4174944519", size = 4778341 },
+    { url = "https://files.pythonhosted.org/packages/a4/05/56c359e07275911ed5f35ab1d63c8cd3360d395fb91e43927a2ae90b0322/lxml-5.3.1-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:b450d7cabcd49aa7ab46a3c6aa3ac7e1593600a1a0605ba536ec0f1b99a04322", size = 5345450 },
+    { url = "https://files.pythonhosted.org/packages/b7/f4/f95e3ae12e9f32fbcde00f9affa6b0df07f495117f62dbb796a9a31c84d6/lxml-5.3.1-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:4df0ec814b50275ad6a99bc82a38b59f90e10e47714ac9871e1b223895825468", size = 4908336 },
+    { url = "https://files.pythonhosted.org/packages/c5/f8/309546aec092434166a6e11c7dcecb5c2d0a787c18c072d61e18da9eba57/lxml-5.3.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d184f85ad2bb1f261eac55cddfcf62a70dee89982c978e92b9a74a1bfef2e367", size = 4986049 },
+    { url = "https://files.pythonhosted.org/packages/71/1c/b951817cb5058ca7c332d012dfe8bc59dabd0f0a8911ddd7b7ea8e41cfbd/lxml-5.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b725e70d15906d24615201e650d5b0388b08a5187a55f119f25874d0103f90dd", size = 4860351 },
+    { url = "https://files.pythonhosted.org/packages/31/23/45feba8dae1d35fcca1e51b051f59dc4223cbd23e071a31e25f3f73938a8/lxml-5.3.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a31fa7536ec1fb7155a0cd3a4e3d956c835ad0a43e3610ca32384d01f079ea1c", size = 5421580 },
+    { url = "https://files.pythonhosted.org/packages/61/69/be245d7b2dbef81c542af59c97fcd641fbf45accf2dc1c325bae7d0d014c/lxml-5.3.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3c3c8b55c7fc7b7e8877b9366568cc73d68b82da7fe33d8b98527b73857a225f", size = 5285778 },
+    { url = "https://files.pythonhosted.org/packages/69/06/128af2ed04bac99b8f83becfb74c480f1aa18407b5c329fad457e08a1bf4/lxml-5.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d61ec60945d694df806a9aec88e8f29a27293c6e424f8ff91c80416e3c617645", size = 5054455 },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/f03a21cf6cc75cdd083563e509c7b6b159d761115c4142abb5481094ed8c/lxml-5.3.1-cp312-cp312-win32.whl", hash = "sha256:f4eac0584cdc3285ef2e74eee1513a6001681fd9753b259e8159421ed28a72e5", size = 3486315 },
+    { url = "https://files.pythonhosted.org/packages/2b/9c/8abe21585d20ef70ad9cec7562da4332b764ed69ec29b7389d23dfabcea0/lxml-5.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:29bfc8d3d88e56ea0a27e7c4897b642706840247f59f4377d81be8f32aa0cfbf", size = 3816925 },
+    { url = "https://files.pythonhosted.org/packages/94/1c/724931daa1ace168e0237b929e44062545bf1551974102a5762c349c668d/lxml-5.3.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c093c7088b40d8266f57ed71d93112bd64c6724d31f0794c1e52cc4857c28e0e", size = 8171881 },
+    { url = "https://files.pythonhosted.org/packages/67/0c/857b8fb6010c4246e66abeebb8639eaabba60a6d9b7c606554ecc5cbf1ee/lxml-5.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b0884e3f22d87c30694e625b1e62e6f30d39782c806287450d9dc2fdf07692fd", size = 4440394 },
+    { url = "https://files.pythonhosted.org/packages/61/72/c9e81de6a000f9682ccdd13503db26e973b24c68ac45a7029173237e3eed/lxml-5.3.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1637fa31ec682cd5760092adfabe86d9b718a75d43e65e211d5931809bc111e7", size = 5037860 },
+    { url = "https://files.pythonhosted.org/packages/24/26/942048c4b14835711b583b48cd7209bd2b5f0b6939ceed2381a494138b14/lxml-5.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a364e8e944d92dcbf33b6b494d4e0fb3499dcc3bd9485beb701aa4b4201fa414", size = 4782513 },
+    { url = "https://files.pythonhosted.org/packages/e2/65/27792339caf00f610cc5be32b940ba1e3009b7054feb0c4527cebac228d4/lxml-5.3.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:779e851fd0e19795ccc8a9bb4d705d6baa0ef475329fe44a13cf1e962f18ff1e", size = 5305227 },
+    { url = "https://files.pythonhosted.org/packages/18/e1/25f7aa434a4d0d8e8420580af05ea49c3e12db6d297cf5435ac0a054df56/lxml-5.3.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c4393600915c308e546dc7003d74371744234e8444a28622d76fe19b98fa59d1", size = 4829846 },
+    { url = "https://files.pythonhosted.org/packages/fe/ed/faf235e0792547d24f61ee1448159325448a7e4f2ab706503049d8e5df19/lxml-5.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:673b9d8e780f455091200bba8534d5f4f465944cbdd61f31dc832d70e29064a5", size = 4949495 },
+    { url = "https://files.pythonhosted.org/packages/e5/e1/8f572ad9ed6039ba30f26dd4c2c58fb90f79362d2ee35ca3820284767672/lxml-5.3.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2e4a570f6a99e96c457f7bec5ad459c9c420ee80b99eb04cbfcfe3fc18ec6423", size = 4773415 },
+    { url = "https://files.pythonhosted.org/packages/a3/75/6b57166b9d1983dac8f28f354e38bff8d6bcab013a241989c4d54c72701b/lxml-5.3.1-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:71f31eda4e370f46af42fc9f264fafa1b09f46ba07bdbee98f25689a04b81c20", size = 5337710 },
+    { url = "https://files.pythonhosted.org/packages/cc/71/4aa56e2daa83bbcc66ca27b5155be2f900d996f5d0c51078eaaac8df9547/lxml-5.3.1-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:42978a68d3825eaac55399eb37a4d52012a205c0c6262199b8b44fcc6fd686e8", size = 4897362 },
+    { url = "https://files.pythonhosted.org/packages/65/10/3fa2da152cd9b49332fd23356ed7643c9b74cad636ddd5b2400a9730d12b/lxml-5.3.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8b1942b3e4ed9ed551ed3083a2e6e0772de1e5e3aca872d955e2e86385fb7ff9", size = 4977795 },
+    { url = "https://files.pythonhosted.org/packages/de/d2/e1da0f7b20827e7b0ce934963cb6334c1b02cf1bb4aecd218c4496880cb3/lxml-5.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85c4f11be9cf08917ac2a5a8b6e1ef63b2f8e3799cec194417e76826e5f1de9c", size = 4858104 },
+    { url = "https://files.pythonhosted.org/packages/a5/35/063420e1b33d3308f5aa7fcbdd19ef6c036f741c9a7a4bd5dc8032486b27/lxml-5.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:231cf4d140b22a923b1d0a0a4e0b4f972e5893efcdec188934cc65888fd0227b", size = 5416531 },
+    { url = "https://files.pythonhosted.org/packages/c3/83/93a6457d291d1e37adfb54df23498101a4701834258c840381dd2f6a030e/lxml-5.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5865b270b420eda7b68928d70bb517ccbe045e53b1a428129bb44372bf3d7dd5", size = 5273040 },
+    { url = "https://files.pythonhosted.org/packages/39/25/ad4ac8fac488505a2702656550e63c2a8db3a4fd63db82a20dad5689cecb/lxml-5.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7bebc2275016cddf3c997bf8a0f7044160714c64a9b83975670a04e6d2252", size = 5050951 },
+    { url = "https://files.pythonhosted.org/packages/82/74/f7d223c704c87e44b3d27b5e0dde173a2fcf2e89c0524c8015c2b3554876/lxml-5.3.1-cp313-cp313-win32.whl", hash = "sha256:d0751528b97d2b19a388b302be2a0ee05817097bab46ff0ed76feeec24951f78", size = 3485357 },
+    { url = "https://files.pythonhosted.org/packages/80/83/8c54533b3576f4391eebea88454738978669a6cad0d8e23266224007939d/lxml-5.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:91fb6a43d72b4f8863d21f347a9163eecbf36e76e2f51068d59cd004c506f332", size = 3814484 },
 ]
 
 [[package]]
@@ -1560,7 +1615,9 @@ prod = [
     { name = "psycopg", extra = ["c"] },
 ]
 tests = [
+    { name = "beautifulsoup4" },
     { name = "freezegun" },
+    { name = "lxml" },
     { name = "model-bakery" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1620,7 +1677,9 @@ docs = [
 ]
 prod = [{ name = "psycopg", extras = ["c"], specifier = ">=3.2.3,<4.0.0" }]
 tests = [
+    { name = "beautifulsoup4", specifier = ">=4.13.3,<5" },
     { name = "freezegun", specifier = ">=1.5.1,<2.0.0" },
+    { name = "lxml", specifier = ">=5.3.1,<6" },
     { name = "model-bakery", specifier = ">=1.20.4,<2.0.0" },
     { name = "pytest", specifier = ">=8.3.5,<9.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0,<7.0.0" },
@@ -1643,6 +1702,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1", size = 86699 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a", size = 93002 },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/ce/fbaeed4f9fb8b2daa961f90591662df6a86c1abf25c548329a86920aedfb/soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb", size = 101569 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c2/fe97d779f3ef3b15f05c94a2f1e3d21732574ed441687474db9d342a7315/soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9", size = 36186 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Passage de la vue de logout en POST (cf. https://docs.djangoproject.com/en/4.2/releases/4.1/#log-out-via-get)
- On ne passe plus d'objets non-sauvés en argument de la méthode filter des QuerySet (cf. https://docs.djangoproject.com/en/4.2/releases/4.1/#id2, au 8ème point)
- Changement du chemin d'import de `RouteContext` depuis ninja_extra (cf. https://github.com/eadwinCode/django-ninja-extra/pull/243 et https://github.com/eadwinCode/django-ninja-extra/releases/tag/0.22.4)
- Augmentation de la taille max de pagination de 199 à 200 (cf. https://github.com/eadwinCode/django-ninja-extra/pull/239). Ce changement dans ninja_extra devrait aussi résoudre [cette issue Sentry](https://sentry.ae.utbm.fr/organizations/sentry/issues/176/?environment=production&project=2&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=12)
- Refactor de la vérification des droits de `PageCreateView` et `RefoundAccountView` (J'ai pas transformé `RefoundAccountView` en `PermissionRequiredMixin`, par contre, parce que ça impliquerait de faire une migration)

Pour retravailler les tests de `PageCreateView`, j'ai ajouté BeautifulSoup aux dépendances du projet