### PR TITLE
Remove galaxy from production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false  # don't interrupt the other test processes
       matrix:
-        pytest-mark: [slow, not slow]
+        pytest-mark: [not slow]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -205,14 +205,6 @@ class UserTabsMixin(TabedViewMixin):
                 "name": _("Pictures"),
             },
         ]
-        if settings.SITH_ENABLE_GALAXY and self.request.user.was_subscribed:
-            tab_list.append(
-                {
-                    "url": reverse("galaxy:user", kwargs={"user_id": user.id}),
-                    "slug": "galaxy",
-                    "name": _("Galaxy"),
-                }
-            )
         if self.request.user == user:
             tab_list.append(
                 {"url": reverse("core:user_tools"), "slug": "tools", "name": _("Tools")}

--- a/galaxy/tests.py
+++ b/galaxy/tests.py
@@ -33,6 +33,7 @@ from core.models import User
 from galaxy.models import Galaxy
 
 
+@pytest.mark.skip(reason="Galaxy is disabled for now")
 class TestGalaxyModel(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -144,6 +145,7 @@ class TestGalaxyModel(TestCase):
 
 
 @pytest.mark.slow
+@pytest.mark.skip(reason="Galaxy is disabled for now")
 class TestGalaxyView(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/sith/settings.py
+++ b/sith/settings.py
@@ -341,10 +341,6 @@ SITH_URL = env.str("SITH_URL", default="127.0.0.1:8000")
 SITH_NAME = env.str("SITH_NAME", default="AE UTBM")
 SITH_TWITTER = "@ae_utbm"
 
-# Enable experimental features
-# Enable/Disable the galaxy button on user profile (urls stay activated)
-SITH_ENABLE_GALAXY = False
-
 # AE configuration
 # TODO: keep only that first setting, with the ID, and do the same for the other clubs
 SITH_MAIN_CLUB_ID = env.int("SITH_MAIN_CLUB_ID", default=1)

--- a/sith/urls.py
+++ b/sith/urls.py
@@ -53,7 +53,6 @@ urlpatterns = [
     path("sas/", include(("sas.urls", "sas"), namespace="sas")),
     path("election/", include(("election.urls", "election"), namespace="election")),
     path("forum/", include(("forum.urls", "forum"), namespace="forum")),
-    path("galaxy/", include(("galaxy.urls", "galaxy"), namespace="galaxy")),
     path("trombi/", include(("trombi.urls", "trombi"), namespace="trombi")),
     path("matmatronch/", include(("matmat.urls", "matmat"), namespace="matmat")),
     path("pedagogy/", include(("pedagogy.urls", "pedagogy"), namespace="pedagogy")),
@@ -68,7 +67,10 @@ if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     import debug_toolbar
 
-    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]
+    urlpatterns += [
+        path("__debug__/", include(debug_toolbar.urls)),
+        path("galaxy/", include(("galaxy.urls", "galaxy"), namespace="galaxy")),
+    ]
 
 
 def sentry_debug(request):


### PR DESCRIPTION
La galaxy est basiquement une bombe posée sur le site.
Quand la galaxy est générée et qu'on tente d'y accéder, toutes les ressources du PC se retrouvent syphonnées par la Galaxy. 

Mon PC fait pas tourner Cyberpunk 2077, mais c'est pas non plus une patate ; eh bah il freeze. Je ne peux même pas fermer le navigateur ou tuer le processus, parce que le PC ne répond plus du tout. 100% du processeur et la quasi-intégralité de ma RAM y passent.

Jusqu'ici, la Galaxy était accessible, mais sans être référencée, parce qu'elle n'est pas finie. Vu comme la page est dangereuse, je préfère retirer complètement l'URL, en attendant le jour éventuel où ça sera réparé.