### PR TITLE
refactor eboutic command page

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/biomejs/pre-commit
-    rev: "v0.1.0"  # Use the sha / tag you want to point at
+    rev: v0.6.1
     hooks:
       - id: biome-check
         additional_dependencies: ["@biomejs/biome@1.9.4"]

--- a/eboutic/api.py
+++ b/eboutic/api.py
@@ -26,7 +26,7 @@ class EtransactionInfoController(ControllerBase):
             customer=customer, defaults=info.model_dump(exclude_none=True)
         )
 
-    @route.get("/data", url_name="etransaction_data", include_in_schema=False)
+    @route.get("/data", url_name="etransaction_data")
     def fetch_etransaction_data(self):
         """Generate the data to pay an eboutic command with paybox.
 

--- a/eboutic/static/bundled/eboutic/makecommand-index.ts
+++ b/eboutic/static/bundled/eboutic/makecommand-index.ts
@@ -17,12 +17,13 @@ document.addEventListener("alpine:init", () => {
     data: etData,
 
     async fill() {
-      document.getElementById("bank-submit-button").disabled = true;
+      const button = document.getElementById("bank-submit-button") as HTMLButtonElement;
+      button.disabled = true;
       // biome-ignore lint/correctness/noUndeclaredVariables: defined in eboutic_makecommand.jinja
       const res = await fetch(etDataUrl);
       if (res.ok) {
         this.data = await res.json();
-        document.getElementById("bank-submit-button").disabled = false;
+        button.disabled = false;
       }
     },
   });

--- a/eboutic/static/eboutic/css/eboutic.css
+++ b/eboutic/static/eboutic/css/eboutic.css
@@ -158,4 +158,3 @@
     flex-direction: column;
   }
 }
-

--- a/eboutic/templates/eboutic/eboutic_makecommand.jinja
+++ b/eboutic/templates/eboutic/eboutic_makecommand.jinja
@@ -33,116 +33,116 @@
             <td>{{ item.product_unit_price }} €</td>
           </tr>
         {% endfor %}
-        <tbody>
-        </table>
+      </tbody>
+    </table>
 
-        <p>
-          <strong>{% trans %}Basket amount: {% endtrans %}{{ "%0.2f"|format(basket.total) }} €</strong>
+    <p>
+      <strong>{% trans %}Basket amount: {% endtrans %}{{ "%0.2f"|format(basket.total) }} €</strong>
 
-          {% if customer_amount != None %}
-            <br>
-            {% trans %}Current account amount: {% endtrans %}
-            <strong>{{ "%0.2f"|format(customer_amount) }} €</strong>
-
-            {% if not basket.contains_refilling_item %}
-              <br>
-              {% trans %}Remaining account amount: {% endtrans %}
-              <strong>{{ "%0.2f"|format(customer_amount|float - basket.total) }} €</strong>
-            {% endif %}
-          {% endif %}
-        </p>
+      {% if customer_amount != None %}
         <br>
-        {% if settings.SITH_EBOUTIC_CB_ENABLED %}
-          <div
-            class="collapse"
-            :class="{'shadow': collapsed}"
-            x-data="{collapsed: !{{ "true" if billing_infos else "false" }}}"
-            x-cloak
-          >
-            <div class="collapse-header clickable" @click="collapsed = !collapsed">
-              <span class="collapse-header-text">
-                {% trans %}Billing information{% endtrans %}
-              </span>
-              <span class="collapse-header-icon" :class="{'reverse': collapsed}">
-                <i class="fa fa-caret-down"></i>
-              </span>
-            </div>
-            <form
-              class="collapse-body"
-              id="billing_info_form"
-              x-data="billing_infos({{ user.id }})"
-              x-show="collapsed"
-              x-transition.scale.origin.top
-              @submit.prevent="await sendForm()"
-            >
-              {% csrf_token %}
-              {{ billing_form }}
-              <br />
-              <div
-                x-show="[BillingInfoReqState.Success, BillingInfoReqState.Failure].includes(reqState)"
-                class="alert"
-                :class="'alert-' + getAlertColor()"
-                x-transition
-              >
-                <div class="alert-main" x-text="getAlertMessage()"></div>
-                <div class="clickable" @click="reqState = null">
-                  <i class="fa fa-close"></i>
-                </div>
-              </div>
-              <input
-                type="submit" class="btn btn-blue clickable"
-                value="{% trans %}Validate{% endtrans %}"
-                :disabled="reqState === BillingInfoReqState.Sending"
-              >
-            </form>
-          </div>
+        {% trans %}Current account amount: {% endtrans %}
+        <strong>{{ "%0.2f"|format(customer_amount) }} €</strong>
+
+        {% if not basket.contains_refilling_item %}
           <br>
-          {% if billing_infos_state == BillingInfoState.EMPTY %}
-            <div class="alert alert-yellow">
-              {% trans trimmed %}
-                You must fill your billing infos if you want to pay with your credit card
-              {% endtrans %}
-            </div>
-          {% elif billing_infos_state == BillingInfoState.MISSING_PHONE_NUMBER %}
-            <div class="alert alert-yellow">
-              {% trans trimmed %}
-                The Crédit Agricole changed its policy related to the billing
-                information that must be provided in order to pay with a credit card.
-                If you want to pay with your credit card, you must add a phone number
-                to the data you already provided.
-              {% endtrans %}
-            </div>
-          {% endif %}
-          <form
-            method="post"
-            action="{{ settings.SITH_EBOUTIC_ET_URL }}"
-            name="bank-pay-form"
-            x-data="etransactionData(initialEtData)"
-            @billing-infos-filled.window="await fill()"
+          {% trans %}Remaining account amount: {% endtrans %}
+          <strong>{{ "%0.2f"|format(customer_amount|float - basket.total) }} €</strong>
+        {% endif %}
+      {% endif %}
+    </p>
+    <br>
+    {% if settings.SITH_EBOUTIC_CB_ENABLED %}
+      <div
+        class="collapse"
+        :class="{'shadow': collapsed}"
+        x-data="{collapsed: !{{ "true" if billing_infos else "false" }}}"
+        x-cloak
+      >
+        <div class="collapse-header clickable" @click="collapsed = !collapsed">
+          <span class="collapse-header-text">
+            {% trans %}Billing information{% endtrans %}
+          </span>
+          <span class="collapse-header-icon" :class="{'reverse': collapsed}">
+            <i class="fa fa-caret-down"></i>
+          </span>
+        </div>
+        <form
+          class="collapse-body"
+          id="billing_info_form"
+          x-data="billing_infos({{ user.id }})"
+          x-show="collapsed"
+          x-transition.scale.origin.top
+          @submit.prevent="await sendForm()"
+        >
+          {% csrf_token %}
+          {{ billing_form }}
+          <br />
+          <div
+            x-show="[BillingInfoReqState.Success, BillingInfoReqState.Failure].includes(reqState)"
+            class="alert"
+            :class="'alert-' + getAlertColor()"
+            x-transition
           >
-            <template x-for="[key, value] in Object.entries(data)" :key="key">
-              <input type="hidden" :name="key" :value="value">
-            </template>
-            <input
-              type="submit"
-              id="bank-submit-button"
-              {% if billing_infos_state != BillingInfoState.VALID %}disabled="disabled"{% endif %}
-              value="{% trans %}Pay with credit card{% endtrans %}"
-            />
-          </form>
-        {% endif %}
-        {% if basket.contains_refilling_item %}
-          <p>{% trans %}AE account payment disabled because your basket contains refilling items.{% endtrans %}</p>
-        {% elif basket.total > user.account_balance %}
-          <p>{% trans %}AE account payment disabled because you do not have enough money remaining.{% endtrans %}</p>
-        {% else %}
-          <form method="post" action="{{ url('eboutic:pay_with_sith') }}" name="sith-pay-form">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="pay_with_sith_account">
-            <input type="submit" value="{% trans %}Pay with Sith account{% endtrans %}"/>
-          </form>
-        {% endif %}
+            <div class="alert-main" x-text="getAlertMessage()"></div>
+            <div class="clickable" @click="reqState = null">
+              <i class="fa fa-close"></i>
+            </div>
+          </div>
+          <input
+            type="submit" class="btn btn-blue clickable"
+            value="{% trans %}Validate{% endtrans %}"
+            :disabled="reqState === BillingInfoReqState.Sending"
+          >
+        </form>
       </div>
+      <br>
+      {% if billing_infos_state == BillingInfoState.EMPTY %}
+        <div class="alert alert-yellow">
+          {% trans trimmed %}
+            You must fill your billing infos if you want to pay with your credit card
+          {% endtrans %}
+        </div>
+      {% elif billing_infos_state == BillingInfoState.MISSING_PHONE_NUMBER %}
+        <div class="alert alert-yellow">
+          {% trans trimmed %}
+            The Crédit Agricole changed its policy related to the billing
+            information that must be provided in order to pay with a credit card.
+            If you want to pay with your credit card, you must add a phone number
+            to the data you already provided.
+          {% endtrans %}
+        </div>
+      {% endif %}
+      <form
+        method="post"
+        action="{{ settings.SITH_EBOUTIC_ET_URL }}"
+        name="bank-pay-form"
+        x-data="etransactionData(initialEtData)"
+        @billing-infos-filled.window="await fill()"
+      >
+        <template x-for="[key, value] in Object.entries(data)" :key="key">
+          <input type="hidden" :name="key" :value="value">
+        </template>
+        <input
+          type="submit"
+          id="bank-submit-button"
+          {% if billing_infos_state != BillingInfoState.VALID %}disabled="disabled"{% endif %}
+          value="{% trans %}Pay with credit card{% endtrans %}"
+        />
+      </form>
+    {% endif %}
+    {% if basket.contains_refilling_item %}
+      <p>{% trans %}AE account payment disabled because your basket contains refilling items.{% endtrans %}</p>
+    {% elif basket.total > user.account_balance %}
+      <p>{% trans %}AE account payment disabled because you do not have enough money remaining.{% endtrans %}</p>
+    {% else %}
+      <form method="post" action="{{ url('eboutic:pay_with_sith') }}" name="sith-pay-form">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="pay_with_sith_account">
+        <input type="submit" value="{% trans %}Pay with Sith account{% endtrans %}"/>
+      </form>
+    {% endif %}
+  </div>
 {% endblock %}
 
 {% block script %}

--- a/eboutic/templates/eboutic/eboutic_makecommand.jinja
+++ b/eboutic/templates/eboutic/eboutic_makecommand.jinja
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block additional_js %}
-  <script src="{{ static('bundled/eboutic/makecommand-index.ts') }}" defer></script>
+  <script type="module" src="{{ static('bundled/eboutic/makecommand-index.ts') }}"></script>
 {% endblock %}
 
 {% block content %}
@@ -56,7 +56,7 @@
           <div
             class="collapse"
             :class="{'shadow': collapsed}"
-            x-data="{collapsed: !billingInfoExist}"
+            x-data="{collapsed: !{{ "true" if billing_infos else "false" }}}"
             x-cloak
           >
             <div class="collapse-header clickable" @click="collapsed = !collapsed">
@@ -70,7 +70,7 @@
             <form
               class="collapse-body"
               id="billing_info_form"
-              x-data="billing_infos"
+              x-data="billing_infos({{ user.id }})"
               x-show="collapsed"
               x-transition.scale.origin.top
               @submit.prevent="await sendForm()"
@@ -79,7 +79,7 @@
               {{ billing_form }}
               <br />
               <div
-                x-show="[BillingInfoReqState.SUCCESS, BillingInfoReqState.FAILURE].includes(reqState)"
+                x-show="[BillingInfoReqState.Success, BillingInfoReqState.Failure].includes(reqState)"
                 class="alert"
                 :class="'alert-' + getAlertColor()"
                 x-transition
@@ -92,19 +92,20 @@
               <input
                 type="submit" class="btn btn-blue clickable"
                 value="{% trans %}Validate{% endtrans %}"
-                :disabled="reqState === BillingInfoReqState.SENDING"
+                :disabled="reqState === BillingInfoReqState.Sending"
               >
             </form>
           </div>
           <br>
           {% if billing_infos_state == BillingInfoState.EMPTY %}
             <div class="alert alert-yellow">
-              {% trans %}You must fill your billing infos if you want to pay with your credit
-                card{% endtrans %}
+              {% trans trimmed %}
+                You must fill your billing infos if you want to pay with your credit card
+              {% endtrans %}
             </div>
           {% elif billing_infos_state == BillingInfoState.MISSING_PHONE_NUMBER %}
             <div class="alert alert-yellow">
-              {% trans %}
+              {% trans trimmed %}
                 The Crédit Agricole changed its policy related to the billing
                 information that must be provided in order to pay with a credit card.
                 If you want to pay with your credit card, you must add a phone number
@@ -112,8 +113,14 @@
               {% endtrans %}
             </div>
           {% endif %}
-          <form method="post" action="{{ settings.SITH_EBOUTIC_ET_URL }}" name="bank-pay-form">
-            <template x-data x-for="[key, value] in Object.entries($store.billing_inputs.data)">
+          <form
+            method="post"
+            action="{{ settings.SITH_EBOUTIC_ET_URL }}"
+            name="bank-pay-form"
+            x-data="etransactionData(initialEtData)"
+            @billing-infos-filled.window="await fill()"
+          >
+            <template x-for="[key, value] in Object.entries(data)" :key="key">
               <input type="hidden" :name="key" :value="value">
             </template>
             <input
@@ -140,17 +147,11 @@
 
 {% block script %}
   <script>
-    const billingInfoUrl = '{{ url("api:put_billing_info", user_id=request.user.id) }}';
-    const etDataUrl = '{{ url("api:etransaction_data") }}';
-    const billingInfoExist = {{ "true" if billing_infos else "false" }};
-    const billingInfoSuccessMessage = "{% trans %}Billing info registration success{% endtrans %}";
-    const billingInfoFailureMessage = "{% trans %}Billing info registration failure{% endtrans %}";
-
-    {% if billing_infos %}
-      const etData = {{ billing_infos|safe }}
-    {% else %}
-      const etData = {}
-    {% endif %}
+    {% if billing_infos -%}
+      const initialEtData = {{ billing_infos|safe }}
+    {%- else -%}
+      const initialEtData = {}
+    {%- endif %}
   </script>
   {{ super() }}
 {% endblock %}

--- a/eboutic/templates/eboutic/eboutic_makecommand.jinja
+++ b/eboutic/templates/eboutic/eboutic_makecommand.jinja
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block additional_js %}
-  <script src="{{ static('eboutic/js/makecommand.js') }}" defer></script>
+  <script src="{{ static('bundled/eboutic/makecommand-index.ts') }}" defer></script>
 {% endblock %}
 
 {% block content %}

--- a/eboutic/views.py
+++ b/eboutic/views.py
@@ -26,7 +26,9 @@ from cryptography.hazmat.primitives.hashes import SHA1
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import (
+    LoginRequiredMixin,
+)
 from django.core.exceptions import SuspiciousOperation
 from django.db import DatabaseError, transaction
 from django.http import HttpRequest, HttpResponse

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-06 16:58+0200\n"
+"POT-Creation-Date: 2025-04-06 15:54+0200\n"
 "PO-Revision-Date: 2016-07-18\n"
 "Last-Translator: Maréchal <thomas.girod@utbm.fr\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -3831,25 +3831,18 @@ msgstr "Informations de facturation"
 
 #: eboutic/templates/eboutic/eboutic_makecommand.jinja
 msgid ""
-"You must fill your billing infos if you want to pay with your credit\n"
-"                card"
+"You must fill your billing infos if you want to pay with your credit card"
 msgstr ""
 "Vous devez renseigner vos coordonnées de facturation si vous voulez payer "
 "par carte bancaire"
 
 #: eboutic/templates/eboutic/eboutic_makecommand.jinja
 msgid ""
-"\n"
-"                The Crédit Agricole changed its policy related to the "
-"billing\n"
-"                information that must be provided in order to pay with a "
-"credit card.\n"
-"                If you want to pay with your credit card, you must add a "
-"phone number\n"
-"                to the data you already provided.\n"
-"              "
+"The Crédit Agricole changed its policy related to the billing information "
+"that must be provided in order to pay with a credit card. If you want to pay "
+"with your credit card, you must add a phone number to the data you already "
+"provided."
 msgstr ""
-"\n"
 "Le Crédit Agricole a changé  sa politique relative aux informations à "
 "fournir pour effectuer un paiement par carte bancaire. De ce fait, si vous "
 "souhaitez payer par carte, vous devez rajouter un numéro de téléphone aux "
@@ -3875,14 +3868,6 @@ msgstr ""
 #: eboutic/templates/eboutic/eboutic_makecommand.jinja
 msgid "Pay with Sith account"
 msgstr "Payer avec un compte AE"
-
-#: eboutic/templates/eboutic/eboutic_makecommand.jinja
-msgid "Billing info registration success"
-msgstr "Informations de facturation enregistrées"
-
-#: eboutic/templates/eboutic/eboutic_makecommand.jinja
-msgid "Billing info registration failure"
-msgstr "Echec de l'enregistrement des informations de facturation."
 
 #: eboutic/templates/eboutic/eboutic_payment_result.jinja
 msgid "Payment successful"

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-28 13:52+0100\n"
+"POT-Creation-Date: 2025-04-06 15:47+0200\n"
 "PO-Revision-Date: 2024-09-17 11:54+0200\n"
 "Last-Translator: Sli <antoine@bartuccio.fr>\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -201,9 +201,17 @@ msgstr "Types de produits réordonnés !"
 msgid "Product type reorganisation failed with status code : %d"
 msgstr "La réorganisation des types de produit a échoué avec le code : %d"
 
-#: eboutic/static/eboutic/js/makecommand.js
+#: eboutic/static/bundled/eboutic/makecommand-index.ts
 msgid "Incorrect value"
 msgstr "Valeur incorrecte"
+
+#: eboutic/static/bundled/eboutic/makecommand-index.ts
+msgid "Billing info registration success"
+msgstr "Informations de facturation enregistrées"
+
+#: eboutic/static/bundled/eboutic/makecommand-index.ts
+msgid "Billing info registration failure"
+msgstr "Echec de l'enregistrement des informations de facturation."
 
 #: sas/static/bundled/sas/pictures-download-index.ts
 msgid "pictures.%(extension)s"


### PR DESCRIPTION
C'était vieux, c'était legacy, et ça a cassé quand on a rajouté la vérification csrf sur l'API.

J'ai juste typescriptifié et arrangé quelques trucs, mais globalement l'idée reste la même qu'avant. A l'occasion, ça pourra être cool d'utiliser plutôt htmx pour le formulaire des infos de facturation.