### PR TITLE
Remote calendar link for external sync

### DIFF
--- a/com/static/bundled/com/components/ics-calendar-index.ts
+++ b/com/static/bundled/com/components/ics-calendar-index.ts
@@ -310,9 +310,10 @@ export class IcsCalendar extends inheritHtmlElement("div") {
             const button = event.target as HTMLButtonElement;
             button.classList.add("text-copy");
             button.setAttribute(
-              "data-tooltip",
+              "tooltip",
               gettext("Calendar link copied to the clipboard"),
             );
+            button.setAttribute("position", "top");
             navigator.clipboard.writeText(
               new URL(
                 await makeUrl(calendarCalendarInternal),
@@ -323,7 +324,8 @@ export class IcsCalendar extends inheritHtmlElement("div") {
               button.classList.remove("text-copied");
               button.classList.add("text-copied");
               button.classList.remove("text-copy");
-              button.removeAttribute("data-tooltip");
+              button.removeAttribute("tooltip");
+              button.removeAttribute("position");
             }, 700);
           },
         },

--- a/com/static/bundled/com/components/ics-calendar-index.ts
+++ b/com/static/bundled/com/components/ics-calendar-index.ts
@@ -303,10 +303,36 @@ export class IcsCalendar extends inheritHtmlElement("div") {
     this.calendar = new Calendar(this.node, {
       plugins: [dayGridPlugin, iCalendarPlugin, listPlugin],
       locales: [frLocale, enLocale],
+      customButtons: {
+        getCalendarLink: {
+          text: gettext("Copy calendar link"),
+          click: async (event: Event) => {
+            const button = event.target as HTMLButtonElement;
+            button.classList.add("text-copy");
+            button.setAttribute(
+              "tooltip",
+              gettext("Calendar link copied to the clipboard"),
+            );
+            navigator.clipboard.writeText(
+              new URL(
+                await makeUrl(calendarCalendarInternal),
+                window.location.origin,
+              ).toString(),
+            );
+            setTimeout(() => {
+              button.classList.remove("text-copied");
+              button.classList.add("text-copied");
+              button.classList.remove("text-copy");
+              button.removeAttribute("tooltip");
+            }, 700);
+          },
+        },
+      },
       height: "auto",
       locale: this.locale,
       initialView: this.currentView(),
       headerToolbar: this.currentToolbar(),
+      footerToolbar: { start: "getCalendarLink" },
       eventSources: await this.getEventSources(),
       windowResize: () => {
         this.calendar.changeView(this.currentView());

--- a/com/static/bundled/com/components/ics-calendar-index.ts
+++ b/com/static/bundled/com/components/ics-calendar-index.ts
@@ -44,7 +44,18 @@ export class IcsCalendar extends inheritHtmlElement("div") {
     return this.isMobile() ? "listMonth" : "dayGridMonth";
   }
 
-  currentToolbar() {
+  currentFooterToolbar() {
+    if (this.isMobile()) {
+      return {
+        start: "",
+        center: "getCalendarLink",
+        end: "",
+      };
+    }
+    return { start: "getCalendarLink", center: "", end: "" };
+  }
+
+  currentHeaderToolbar() {
     if (this.isMobile()) {
       return {
         left: "prev,next",
@@ -309,11 +320,14 @@ export class IcsCalendar extends inheritHtmlElement("div") {
           click: async (event: Event) => {
             const button = event.target as HTMLButtonElement;
             button.classList.add("text-copy");
-            button.setAttribute(
-              "tooltip",
-              gettext("Calendar link copied to the clipboard"),
-            );
-            button.setAttribute("position", "top");
+            if (!button.hasAttribute("position")) {
+              button.setAttribute("tooltip", gettext("Link copied"));
+              button.setAttribute("position", "top");
+              button.setAttribute("no-hover", "");
+            }
+            if (button.classList.contains("text-copied")) {
+              button.classList.remove("text-copied");
+            }
             navigator.clipboard.writeText(
               new URL(
                 await makeUrl(calendarCalendarInternal),
@@ -324,21 +338,20 @@ export class IcsCalendar extends inheritHtmlElement("div") {
               button.classList.remove("text-copied");
               button.classList.add("text-copied");
               button.classList.remove("text-copy");
-              button.removeAttribute("tooltip");
-              button.removeAttribute("position");
-            }, 700);
+            }, 1500);
           },
         },
       },
       height: "auto",
       locale: this.locale,
       initialView: this.currentView(),
-      headerToolbar: this.currentToolbar(),
-      footerToolbar: { start: "getCalendarLink" },
+      headerToolbar: this.currentHeaderToolbar(),
+      footerToolbar: this.currentFooterToolbar(),
       eventSources: await this.getEventSources(),
       windowResize: () => {
         this.calendar.changeView(this.currentView());
-        this.calendar.setOption("headerToolbar", this.currentToolbar());
+        this.calendar.setOption("headerToolbar", this.currentHeaderToolbar());
+        this.calendar.setOption("footerToolbar", this.currentFooterToolbar());
       },
       eventClick: (event) => {
         // Avoid our popup to be deleted because we clicked outside of it

--- a/com/static/bundled/com/components/ics-calendar-index.ts
+++ b/com/static/bundled/com/components/ics-calendar-index.ts
@@ -310,7 +310,7 @@ export class IcsCalendar extends inheritHtmlElement("div") {
             const button = event.target as HTMLButtonElement;
             button.classList.add("text-copy");
             button.setAttribute(
-              "tooltip",
+              "data-tooltip",
               gettext("Calendar link copied to the clipboard"),
             );
             navigator.clipboard.writeText(
@@ -323,7 +323,7 @@ export class IcsCalendar extends inheritHtmlElement("div") {
               button.classList.remove("text-copied");
               button.classList.add("text-copied");
               button.classList.remove("text-copy");
-              button.removeAttribute("tooltip");
+              button.removeAttribute("data-tooltip");
             }, 700);
           },
         },

--- a/com/static/com/components/ics-calendar.scss
+++ b/com/static/com/components/ics-calendar.scss
@@ -98,4 +98,21 @@ ics-calendar {
       background: white;
     }
   }
+
+  .fc .fc-toolbar.fc-footer-toolbar {
+    margin-bottom: 0.5em;
+  }
+
+  button.text-copy,
+  button.text-copy:focus,
+  button.text-copy:hover {
+    background-color: green !important;
+    transition: 200ms linear;
+  }
+
+  button.text-copied,
+  button.text-copied:focus,
+  button.text-copied:hover {
+    transition: 200ms linear;
+  }
 }

--- a/com/static/com/components/ics-calendar.scss
+++ b/com/static/com/components/ics-calendar.scss
@@ -22,6 +22,8 @@
 ics-calendar {
   border: none;
   box-shadow: none;
+  overflow: visible;
+  z-index: 1;
 
   #event-details {
     z-index: 10;
@@ -106,7 +108,7 @@ ics-calendar {
   button.text-copy,
   button.text-copy:focus,
   button.text-copy:hover {
-    background-color: green !important;
+    background-color: #67AE6E !important;
     transition: 200ms linear;
   }
 
@@ -114,5 +116,36 @@ ics-calendar {
   button.text-copied:focus,
   button.text-copied:hover {
     transition: 200ms linear;
+  }
+
+
+
+  /* Tooltip styles */
+  button[data-tooltip] {
+    position: relative;
+    cursor: pointer;
+  }
+
+  button[data-tooltip]::after {
+    font-size: 10px;
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 120%; /* Adjust this value to position the tooltip above the button */
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #333;
+    color: #fff;
+    padding: 5px 10px;
+    border-radius: 5px;
+    white-space: nowrap;
+    opacity: 0;
+    transition: opacity 0.3s;
+    pointer-events: none;
+    z-index: 99999;
+  }
+
+  button[data-tooltip]:hover::after,
+  button[data-tooltip]:focus::after {
+    opacity: 1;
   }
 }

--- a/com/static/com/components/ics-calendar.scss
+++ b/com/static/com/components/ics-calendar.scss
@@ -107,16 +107,17 @@ ics-calendar {
   button.text-copy:focus,
   button.text-copy:hover {
     background-color: #67AE6E !important;
-    transition: 200ms linear;
+    transition: 500ms ease-in;
   }
 
   button.text-copied,
   button.text-copied:focus,
   button.text-copied:hover {
-    transition: 200ms linear;
+    transition: 500ms ease-out;
   }
 
-  [tooltip]::before {
-    font-size: 10px; // this will overflow otherwise
+  button.text-copied[tooltip]::before {
+    opacity: 0;
+    transition: opacity 500ms ease-out;
   }
 }

--- a/com/static/com/components/ics-calendar.scss
+++ b/com/static/com/components/ics-calendar.scss
@@ -22,8 +22,6 @@
 ics-calendar {
   border: none;
   box-shadow: none;
-  overflow: visible;
-  z-index: 1;
 
   #event-details {
     z-index: 10;
@@ -118,34 +116,7 @@ ics-calendar {
     transition: 200ms linear;
   }
 
-
-
-  /* Tooltip styles */
-  button[data-tooltip] {
-    position: relative;
-    cursor: pointer;
-  }
-
-  button[data-tooltip]::after {
-    font-size: 10px;
-    content: attr(data-tooltip);
-    position: absolute;
-    bottom: 120%; /* Adjust this value to position the tooltip above the button */
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #333;
-    color: #fff;
-    padding: 5px 10px;
-    border-radius: 5px;
-    white-space: nowrap;
-    opacity: 0;
-    transition: opacity 0.3s;
-    pointer-events: none;
-    z-index: 99999;
-  }
-
-  button[data-tooltip]:hover::after,
-  button[data-tooltip]:focus::after {
-    opacity: 1;
+  [tooltip]::before {
+    font-size: 10px; // this will overflow otherwise
   }
 }

--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -70,6 +70,12 @@ body {
 
 [tooltip]:hover::before {
   opacity: 1;
+  transition: opacity 500ms ease-in;
+}
+
+[no-hover][tooltip]::before {
+  opacity: 1;
+  transition: opacity 500ms ease-in;
 }
 
 [position="top"][tooltip]::before {

--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -51,24 +51,49 @@ body {
 
 [tooltip]::before {
   @include shadow;
-  opacity: 0;
   z-index: 1;
+  pointer-events: none;
   content: attr(tooltip);
-  background: hsl(219.6, 20.8%, 96%);
-  color: $black-color;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #333;
+  color: #fff;
   border: 0.5px solid hsl(0, 0%, 50%);
-  ;
   border-radius: 5px;
-  padding: 5px;
-  top: 1em;
+  padding: 5px 10px;
   position: absolute;
-  margin-top: 5px;
   white-space: nowrap;
+  opacity: 0;
   transition: opacity 500ms ease-out;
+  top: 120%; // Put the tooltip under the element
 }
 
 [tooltip]:hover::before {
   opacity: 1;
+}
+
+[position="top"][tooltip]::before {
+  top: initial;
+  bottom: 120%;
+}
+
+[position="bottom"][tooltip]::before {
+  top: 120%;
+  bottom: initial;
+}
+
+[position="left"][tooltip]::before {
+  top: initial;
+  bottom: 0%;
+  left: initial;
+  right: 65%;
+}
+
+[position="right"][tooltip]::before {
+  top: initial;
+  bottom: 0%;
+  left: 150%;
+  right: initial;
 }
 
 .ib {

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-06 15:47+0200\n"
+"POT-Creation-Date: 2025-04-07 13:56+0200\n"
 "PO-Revision-Date: 2024-09-17 11:54+0200\n"
 "Last-Translator: Sli <antoine@bartuccio.fr>\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -32,6 +32,14 @@ msgstr "Dépublier"
 #: com/static/bundled/com/components/ics-calendar-index.ts
 msgid "Delete"
 msgstr "Supprimer"
+
+#: com/static/bundled/com/components/ics-calendar-index.ts
+msgid "Copy calendar link"
+msgstr "Copier le lien du calendrier"
+
+#: com/static/bundled/com/components/ics-calendar-index.ts
+msgid "Calendar link copied to the clipboard"
+msgstr "Lien du calendrier copié dans le presse papier"
 
 #: com/static/bundled/com/components/moderation-alert-index.ts
 #, javascript-format

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-07 13:56+0200\n"
+"POT-Creation-Date: 2025-04-08 11:42+0200\n"
 "PO-Revision-Date: 2024-09-17 11:54+0200\n"
 "Last-Translator: Sli <antoine@bartuccio.fr>\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -38,8 +38,8 @@ msgid "Copy calendar link"
 msgstr "Copier le lien du calendrier"
 
 #: com/static/bundled/com/components/ics-calendar-index.ts
-msgid "Calendar link copied to the clipboard"
-msgstr "Lien du calendrier copié dans le presse papier"
+msgid "Link copied"
+msgstr "Lien copié"
 
 #: com/static/bundled/com/components/moderation-alert-index.ts
 #, javascript-format

--- a/sith/settings.py
+++ b/sith/settings.py
@@ -78,10 +78,12 @@ DEBUG = env.bool("SITH_DEBUG", default=False)
 TESTING = "pytest" in sys.modules
 INTERNAL_IPS = ["127.0.0.1"]
 
+HTTPS = env.bool("HTTPS", default=True)
+
 # force csrf tokens and cookies to be secure when in https
-CSRF_COOKIE_SECURE = env.bool("HTTPS", default=True)
+CSRF_COOKIE_SECURE = HTTPS
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
-SESSION_COOKIE_SECURE = env.bool("HTTPS", default=True)
+SESSION_COOKIE_SECURE = HTTPS
 X_FRAME_OPTIONS = "SAMEORIGIN"
 
 ALLOWED_HOSTS = ["*"]


### PR DESCRIPTION
Ajoute un bouton pour obtenir le lien du calendrier à des fins de synchronisation.

L'ics génère également maintenant des liens absolus pour tous les événements

https://github.com/user-attachments/assets/f6c2531f-7416-4c6e-abf7-a225b8202f04

