### PR TITLE
Fix news x overflow on mobile

### DIFF
--- a/com/static/com/css/news-list.scss
+++ b/com/static/com/css/news-list.scss
@@ -56,9 +56,11 @@
   #upcoming-events {
     max-height: 600px;
     overflow-y: scroll;
+    overflow-x: clip;
 
     #load-more-news-button {
       text-align: center;
+
       button {
         width: 150px;
       }
@@ -194,6 +196,7 @@
           img {
             height: 75px;
           }
+
           .header_content {
             display: flex;
             flex-direction: column;

--- a/core/static/core/markdown.scss
+++ b/core/static/core/markdown.scss
@@ -15,6 +15,7 @@
   ol,
   p {
     line-height: 22px;
+    word-break: break-word;
   }
 
   code {
@@ -71,6 +72,7 @@
   a:hover {
     text-decoration: underline;
   }
+
   .footnotes {
     font-size: 85%;
   }


### PR DESCRIPTION
On a un petit soucis sur mobile avec les news quand il y a des liens dedans.
J'ai fixé ce problème

Avant :
<img width="607" alt="image" src="https://github.com/user-attachments/assets/0f6ff916-357d-4013-95ee-d3ecfcc02196" />

Après :
<img width="602" alt="image" src="https://github.com/user-attachments/assets/151d52ac-599f-471d-ad71-76fc34ca8c49" />
