### PR TITLE
custom django command for promo logos

### DIFF
--- a/core/management/commands/add_promo_logo.py
+++ b/core/management/commands/add_promo_logo.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+from PIL import Image
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("--numero", type=int)
+        parser.add_argument("--path", type=str)
+
+    def handle(self, *args, **options):
+        if options["path"] and options["numero"]:
+            im = Image.open(options["path"]).resize((120, 120)).convert("RGBA")
+            im.save(f"core/static/core/img/promo_{options['numero']}.png", format="PNG")
+            im.close()


### PR DESCRIPTION
commande pour rajouter les logos de promo automatiquement dans le bon dossier en suivant les instructions de la [documentation](https://ae-utbm.github.io/sith/howto/logo/). usage `./manage.py add_promo_logo --numero xx --path mon_path`