### PR TITLE
fix 500 on SAS main page for anonymous users

### DIFF
--- a/sas/templates/sas/main.jinja
+++ b/sas/templates/sas/main.jinja
@@ -59,7 +59,7 @@
         {% endfor %}
       </div>
 
-      {% if is_sas_admin %}
+      {% if album_create_fragment %}
         </form>
         <br>
         {{ album_create_fragment }}

--- a/sas/views.py
+++ b/sas/views.py
@@ -65,12 +65,16 @@ class SASMainView(UseFragmentsMixin, TemplateView):
     template_name = "sas/main.jinja"
 
     def get_fragments(self) -> dict[str, FragmentRenderer]:
+        if not self.request.user.has_perm("sas.add_album"):
+            return {}
         form_init = {"parent": SithFile.objects.get(id=settings.SITH_SAS_ROOT_DIR_ID)}
         return {
             "album_create_fragment": AlbumCreateFragment.as_fragment(initial=form_init)
         }
 
     def get_fragment_data(self) -> dict[str, dict[str, Any]]:
+        if not self.request.user.has_perm("sas.add_album"):
+            return {}
         root_user = User.objects.get(pk=settings.SITH_ROOT_USER_ID)
         return {"album_create_fragment": {"owner": root_user}}
 


### PR DESCRIPTION
Quand un utilisateur anonyme tente d'accéder au site, il reçoit une erreur 500 au lieu du message qui lui dit qu'il doit se connecter.