### PR TITLE
Create a js tooltip library

### DIFF
--- a/com/static/bundled/com/components/ics-calendar-index.ts
+++ b/com/static/bundled/com/components/ics-calendar-index.ts
@@ -319,7 +319,7 @@ export class IcsCalendar extends inheritHtmlElement("div") {
           click: async (event: Event) => {
             const button = event.target as HTMLButtonElement;
             button.classList.add("text-copy");
-            button.setAttribute("tooltip-class", "text-copy");
+            button.setAttribute("tooltip-class", "calendar-copy-tooltip");
             if (!button.hasAttribute("tooltip-position")) {
               button.setAttribute("tooltip-position", "top");
             }
@@ -334,11 +334,10 @@ export class IcsCalendar extends inheritHtmlElement("div") {
               ).toString(),
             );
             setTimeout(() => {
-              button.setAttribute("tooltip-class", "text-copied");
+              button.setAttribute("tooltip-class", "calendar-copy-tooltip text-copied");
               button.classList.remove("text-copied");
               button.classList.add("text-copied");
               button.classList.remove("text-copy");
-              button.removeAttribute("tooltip");
             }, 1500);
           },
         },

--- a/com/static/bundled/com/components/ics-calendar-index.ts
+++ b/com/static/bundled/com/components/ics-calendar-index.ts
@@ -320,13 +320,13 @@ export class IcsCalendar extends inheritHtmlElement("div") {
             const button = event.target as HTMLButtonElement;
             button.classList.add("text-copy");
             if (!button.hasAttribute("position")) {
-              button.setAttribute("tooltip", gettext("Link copied"));
               button.setAttribute("position", "top");
-              button.setAttribute("no-hover", "");
             }
             if (button.classList.contains("text-copied")) {
               button.classList.remove("text-copied");
             }
+            button.setAttribute("tooltip", gettext("Link copied"));
+            button.dispatchEvent(new Event("mouseover", { bubbles: true }));
             navigator.clipboard.writeText(
               new URL(
                 await makeUrl(calendarCalendarInternal),
@@ -337,6 +337,8 @@ export class IcsCalendar extends inheritHtmlElement("div") {
               button.classList.remove("text-copied");
               button.classList.add("text-copied");
               button.classList.remove("text-copy");
+              button.dispatchEvent(new Event("mouseout", { bubbles: true }));
+              button.removeAttribute("tooltip");
             }, 1500);
           },
         },

--- a/com/static/bundled/com/components/ics-calendar-index.ts
+++ b/com/static/bundled/com/components/ics-calendar-index.ts
@@ -327,7 +327,6 @@ export class IcsCalendar extends inheritHtmlElement("div") {
               button.classList.remove("text-copied");
             }
             button.setAttribute("tooltip", gettext("Link copied"));
-            button.dispatchEvent(new Event("mouseover", { bubbles: true }));
             navigator.clipboard.writeText(
               new URL(
                 await makeUrl(calendarCalendarInternal),
@@ -339,7 +338,6 @@ export class IcsCalendar extends inheritHtmlElement("div") {
               button.classList.remove("text-copied");
               button.classList.add("text-copied");
               button.classList.remove("text-copy");
-              button.dispatchEvent(new Event("mouseout", { bubbles: true }));
               button.removeAttribute("tooltip");
             }, 1500);
           },

--- a/com/static/bundled/com/components/ics-calendar-index.ts
+++ b/com/static/bundled/com/components/ics-calendar-index.ts
@@ -319,8 +319,9 @@ export class IcsCalendar extends inheritHtmlElement("div") {
           click: async (event: Event) => {
             const button = event.target as HTMLButtonElement;
             button.classList.add("text-copy");
-            if (!button.hasAttribute("position")) {
-              button.setAttribute("position", "top");
+            button.setAttribute("tooltip-class", "text-copy");
+            if (!button.hasAttribute("tooltip-position")) {
+              button.setAttribute("tooltip-position", "top");
             }
             if (button.classList.contains("text-copied")) {
               button.classList.remove("text-copied");
@@ -334,6 +335,7 @@ export class IcsCalendar extends inheritHtmlElement("div") {
               ).toString(),
             );
             setTimeout(() => {
+              button.setAttribute("tooltip-class", "text-copied");
               button.classList.remove("text-copied");
               button.classList.add("text-copied");
               button.classList.remove("text-copy");

--- a/com/static/com/components/ics-calendar.scss
+++ b/com/static/com/components/ics-calendar.scss
@@ -117,7 +117,6 @@ ics-calendar {
     transition: 500ms ease-out;
     margin-right: 0.5rem;
   }
-}
 
   .fc .fc-helpButton-button {
     border-radius: 70%;
@@ -136,6 +135,12 @@ ics-calendar {
   }
 }
 
-.tooltip.text-copy {
+.tooltip.calendar-copy-tooltip {
   opacity: 1;
+  transition: opacity 500ms ease-in;
+}
+
+.tooltip.calendar-copy-tooltip.text-copied {
+  opacity: 0;
+  transition: opacity 500ms ease-out;
 }

--- a/com/static/com/components/ics-calendar.scss
+++ b/com/static/com/components/ics-calendar.scss
@@ -115,6 +115,9 @@ ics-calendar {
   button.text-copied:focus,
   button.text-copied:hover {
     transition: 500ms ease-out;
+  }
+
+  .fc .fc-getCalendarLink-button {
     margin-right: 0.5rem;
   }
 

--- a/com/static/com/components/ics-calendar.scss
+++ b/com/static/com/components/ics-calendar.scss
@@ -117,6 +117,7 @@ ics-calendar {
     transition: 500ms ease-out;
     margin-right: 0.5rem;
   }
+}
 
   .fc .fc-helpButton-button {
     border-radius: 70%;
@@ -133,4 +134,8 @@ ics-calendar {
   .fc .fc-helpButton-button:hover {
     background-color: rgba(20, 20, 20, 0.6);
   }
+}
+
+.tooltip.text-copy {
+  opacity: 1;
 }

--- a/com/static/com/components/ics-calendar.scss
+++ b/com/static/com/components/ics-calendar.scss
@@ -1,4 +1,5 @@
 @import "core/static/core/colors";
+@import "core/static/core/tooltips";
 
 
 :root {
@@ -115,11 +116,6 @@ ics-calendar {
   button.text-copied:hover {
     transition: 500ms ease-out;
     margin-right: 0.5rem;
-  }
-
-  button.text-copied[tooltip]::before {
-    opacity: 0;
-    transition: opacity 500ms ease-out;
   }
 
   .fc .fc-helpButton-button {

--- a/core/static/bundled/core/tooltips-index.ts
+++ b/core/static/bundled/core/tooltips-index.ts
@@ -1,0 +1,62 @@
+import { type Placement, computePosition } from "@floating-ui/dom";
+
+/**
+ * Library usage:
+ * Add a `tooltip` attribute to any html element with it's tooltip text
+ * You can control the position of the tooltp with the `position` attribute
+ * Allowed placements are `top`, `right`, `bottom`, `left`
+ * You can add `-start` and `-end` to all allowed placement values
+ **/
+
+function getPlacement(element: HTMLElement): Placement {
+  const position = element.getAttribute("position");
+  if (position) {
+    return position as Placement;
+  }
+  return "bottom";
+}
+
+function getTooltip(element: HTMLElement) {
+  for (const tooltip of document.body.getElementsByClassName("tooltip")) {
+    if (tooltip.textContent === element.getAttribute("tooltip")) {
+      return tooltip as HTMLElement;
+    }
+  }
+
+  const tooltip = document.createElement("div");
+  document.body.append(tooltip);
+  tooltip.classList.add("tooltip");
+  tooltip.innerText = element.getAttribute("tooltip");
+
+  return tooltip;
+}
+
+addEventListener("mouseover", (event: MouseEvent) => {
+  const target = event.target as HTMLElement;
+  if (!target.hasAttribute("tooltip")) {
+    return;
+  }
+
+  const tooltip = getTooltip(target);
+  tooltip.setAttribute("tooltip-status", "open");
+
+  computePosition(target, tooltip, {
+    placement: getPlacement(target),
+  }).then(({ x, y }) => {
+    Object.assign(tooltip.style, {
+      left: `${x}px`,
+      top: `${y}px`,
+    });
+  });
+
+  document.body.append(tooltip);
+});
+
+addEventListener("mouseout", (event: MouseEvent) => {
+  const target = event.target as HTMLElement;
+  if (!target.hasAttribute("tooltip")) {
+    return;
+  }
+
+  getTooltip(target).setAttribute("tooltip-status", "close");
+});

--- a/core/static/bundled/core/tooltips-index.ts
+++ b/core/static/bundled/core/tooltips-index.ts
@@ -110,7 +110,9 @@ function tooltipMouseover(event: MouseEvent) {
     });
   });
 
-  document.body.append(tooltip);
+  if (!tooltip.isConnected) {
+    document.body.append(tooltip);
+  }
 }
 
 function tooltipMouseout(event: MouseEvent) {
@@ -138,6 +140,8 @@ new MutationObserver((mutations: MutationRecord[]) => {
       target.addEventListener("mouseout", tooltipMouseout);
       if (target.matches(":hover")) {
         target.dispatchEvent(new Event("mouseover", { bubbles: true }));
+      } else {
+        target.dispatchEvent(new Event("mouseout", { bubbles: true }));
       }
     } else if (tooltips.has(target)) {
       // Remove corresponding tooltip
@@ -147,7 +151,7 @@ new MutationObserver((mutations: MutationRecord[]) => {
   }
 }).observe(document.body, {
   attributes: true,
-  attributeFilter: ["tooltip"],
+  attributeFilter: ["tooltip", "tooltip-class", "toolitp-position"],
   subtree: true,
 });
 

--- a/core/static/bundled/core/tooltips-index.ts
+++ b/core/static/bundled/core/tooltips-index.ts
@@ -8,6 +8,8 @@ import { type Placement, computePosition } from "@floating-ui/dom";
  * You can add `-start` and `-end` to all allowed placement values
  **/
 
+const tooltips = new Map();
+
 function getPlacement(element: HTMLElement): Placement {
   const position = element.getAttribute("position");
   if (position) {
@@ -16,17 +18,20 @@ function getPlacement(element: HTMLElement): Placement {
   return "bottom";
 }
 
-function getTooltip(element: HTMLElement) {
-  for (const tooltip of document.body.getElementsByClassName("tooltip")) {
-    if (tooltip.textContent === element.getAttribute("tooltip")) {
-      return tooltip as HTMLElement;
-    }
-  }
-
+function createTooltip(element: HTMLElement) {
   const tooltip = document.createElement("div");
   document.body.append(tooltip);
   tooltip.classList.add("tooltip");
   tooltip.innerText = element.getAttribute("tooltip");
+  tooltips.set(element, tooltip);
+  return tooltip;
+}
+
+function getTooltip(element: HTMLElement) {
+  const tooltip = tooltips.get(element);
+  if (tooltip === undefined) {
+    return createTooltip(element);
+  }
 
   return tooltip;
 }

--- a/core/static/bundled/core/tooltips-index.ts
+++ b/core/static/bundled/core/tooltips-index.ts
@@ -136,6 +136,13 @@ new MutationObserver((mutations: MutationRecord[]) => {
     if (target.hasAttribute("tooltip")) {
       target.addEventListener("mouseover", tooltipMouseover);
       target.addEventListener("mouseout", tooltipMouseout);
+      if (target.matches(":hover")) {
+        target.dispatchEvent(new Event("mouseover", { bubbles: true }));
+      }
+    } else if (tooltips.has(target)) {
+      // Remove corresponding tooltip
+      tooltips.get(target).remove();
+      tooltips.delete(target);
     }
   }
 }).observe(document.body, {

--- a/core/static/bundled/core/tooltips-index.ts
+++ b/core/static/bundled/core/tooltips-index.ts
@@ -109,10 +109,6 @@ function tooltipMouseover(event: MouseEvent) {
       top: `${y}px`,
     });
   });
-
-  if (!tooltip.isConnected) {
-    document.body.append(tooltip);
-  }
 }
 
 function tooltipMouseout(event: MouseEvent) {
@@ -151,7 +147,7 @@ new MutationObserver((mutations: MutationRecord[]) => {
   }
 }).observe(document.body, {
   attributes: true,
-  attributeFilter: ["tooltip", "tooltip-class", "toolitp-position"],
+  attributeFilter: ["tooltip", "tooltip-class", "toolitp-position", "tooltip-id"],
   subtree: true,
 });
 

--- a/core/static/bundled/core/tooltips-index.ts
+++ b/core/static/bundled/core/tooltips-index.ts
@@ -1,12 +1,22 @@
-import { type Placement, computePosition, offset } from "@floating-ui/dom";
+import {
+  type Placement,
+  autoPlacement,
+  computePosition,
+  flip,
+  offset,
+  size,
+} from "@floating-ui/dom";
 
 /**
  * Library usage:
  *
  * Add a `tooltip` attribute to any html element with it's tooltip text
  * You can control the position of the tooltp with the `tooltip-position` attribute
- * Allowed placements are `top`, `right`, `bottom`, `left`
- * You can add `-start` and `-end` to all allowed placement values
+ * Allowed placements are `auto`, `top`, `right`, `bottom`, `left`
+ * You can add `-start` and `-end` to all allowed placement values except for `auto`
+ * Default placement is `auto`
+ * Note: placement are suggestions and the position could change if the popup gets
+ *       outside of the screen.
  *
  * You can customize your tooltip by passing additionnal classes or ids to it
  * You can use `tooltip-class` and `tooltip-id` to add additional elements to the
@@ -24,12 +34,30 @@ type Status = "open" | "close";
 
 const tooltips = new Map();
 
-function getPlacement(element: HTMLElement): Placement {
+function getPosition(element: HTMLElement): Placement | "auto" {
   const position = element.getAttribute("tooltip-position");
   if (position) {
-    return position as Placement;
+    return position as Placement | "auto";
   }
-  return "bottom";
+  return "auto";
+}
+
+function getMiddleware(element: HTMLElement) {
+  const middleware = [offset(6), size()];
+  if (getPosition(element) === "auto") {
+    middleware.push(autoPlacement());
+  } else {
+    middleware.push(flip());
+  }
+  return { middleware: middleware };
+}
+
+function getPlacement(element: HTMLElement) {
+  const position = getPosition(element);
+  if (position !== "auto") {
+    return { placement: position };
+  }
+  return {};
 }
 
 function createTooltip(element: HTMLElement) {
@@ -48,9 +76,9 @@ function updateTooltip(element: HTMLElement, tooltip: HTMLElement, status: Statu
     { src: "tooltip-class", dst: "class", default: ["tooltip"] },
     { src: "tooltip-id", dst: "id", default: [] },
   ]) {
-    let populated = attributes.default;
+    const populated = attributes.default;
     if (element.hasAttribute(attributes.src)) {
-      populated = populated.concat(element.getAttribute(attributes.src).split(" "));
+      populated.push(...element.getAttribute(attributes.src).split(" "));
     }
     tooltip.setAttribute(attributes.dst, populated.join(" "));
   }
@@ -75,8 +103,8 @@ addEventListener("mouseover", (event: MouseEvent) => {
   updateTooltip(target, tooltip, "open");
 
   computePosition(target, tooltip, {
-    placement: getPlacement(target),
-    middleware: [offset(6)],
+    ...getPlacement(target),
+    ...getMiddleware(target),
   }).then(({ x, y }) => {
     Object.assign(tooltip.style, {
       left: `${x}px`,

--- a/core/static/bundled/core/tooltips-index.ts
+++ b/core/static/bundled/core/tooltips-index.ts
@@ -1,7 +1,8 @@
-import { type Placement, computePosition } from "@floating-ui/dom";
+import { type Placement, computePosition, offset } from "@floating-ui/dom";
 
 /**
  * Library usage:
+ *
  * Add a `tooltip` attribute to any html element with it's tooltip text
  * You can control the position of the tooltp with the `tooltip-position` attribute
  * Allowed placements are `top`, `right`, `bottom`, `left`
@@ -10,6 +11,13 @@ import { type Placement, computePosition } from "@floating-ui/dom";
  * You can customize your tooltip by passing additionnal classes or ids to it
  * You can use `tooltip-class` and `tooltip-id` to add additional elements to the
  * `class` and `id` attribute of the generated tooltip
+ *
+ * @example
+ * ```html
+ * <p tooltip="tooltip text"></p>
+ * <p tooltip="tooltip left" tooltip-position="left"></p>
+ * <div tooltip="tooltip custom class" tooltip-class="custom custom-class"></div>
+ * ```
  **/
 
 type Status = "open" | "close";
@@ -68,6 +76,7 @@ addEventListener("mouseover", (event: MouseEvent) => {
 
   computePosition(target, tooltip, {
     placement: getPlacement(target),
+    middleware: [offset(6)],
   }).then(({ x, y }) => {
     Object.assign(tooltip.style, {
       left: `${x}px`,

--- a/core/static/bundled/core/tooltips-index.ts
+++ b/core/static/bundled/core/tooltips-index.ts
@@ -3,15 +3,21 @@ import { type Placement, computePosition } from "@floating-ui/dom";
 /**
  * Library usage:
  * Add a `tooltip` attribute to any html element with it's tooltip text
- * You can control the position of the tooltp with the `position` attribute
+ * You can control the position of the tooltp with the `tooltip-position` attribute
  * Allowed placements are `top`, `right`, `bottom`, `left`
  * You can add `-start` and `-end` to all allowed placement values
+ *
+ * You can customize your tooltip by passing additionnal classes or ids to it
+ * You can use `tooltip-class` and `tooltip-id` to add additional elements to the
+ * `class` and `id` attribute of the generated tooltip
  **/
+
+type Status = "open" | "close";
 
 const tooltips = new Map();
 
 function getPlacement(element: HTMLElement): Placement {
-  const position = element.getAttribute("position");
+  const position = element.getAttribute("tooltip-position");
   if (position) {
     return position as Placement;
   }
@@ -21,10 +27,25 @@ function getPlacement(element: HTMLElement): Placement {
 function createTooltip(element: HTMLElement) {
   const tooltip = document.createElement("div");
   document.body.append(tooltip);
-  tooltip.classList.add("tooltip");
-  tooltip.innerText = element.getAttribute("tooltip");
   tooltips.set(element, tooltip);
   return tooltip;
+}
+
+function updateTooltip(element: HTMLElement, tooltip: HTMLElement, status: Status) {
+  // Update tooltip status and set it's attributes and content
+  tooltip.setAttribute("tooltip-status", status);
+  tooltip.innerText = element.getAttribute("tooltip");
+
+  for (const attributes of [
+    { src: "tooltip-class", dst: "class", default: ["tooltip"] },
+    { src: "tooltip-id", dst: "id", default: [] },
+  ]) {
+    let populated = attributes.default;
+    if (element.hasAttribute(attributes.src)) {
+      populated = populated.concat(element.getAttribute(attributes.src).split(" "));
+    }
+    tooltip.setAttribute(attributes.dst, populated.join(" "));
+  }
 }
 
 function getTooltip(element: HTMLElement) {
@@ -43,7 +64,7 @@ addEventListener("mouseover", (event: MouseEvent) => {
   }
 
   const tooltip = getTooltip(target);
-  tooltip.setAttribute("tooltip-status", "open");
+  updateTooltip(target, tooltip, "open");
 
   computePosition(target, tooltip, {
     placement: getPlacement(target),
@@ -63,5 +84,5 @@ addEventListener("mouseout", (event: MouseEvent) => {
     return;
   }
 
-  getTooltip(target).setAttribute("tooltip-status", "close");
+  updateTooltip(target, getTooltip(target), "close");
 });

--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -45,17 +45,10 @@ body {
   }
 }
 
-[tooltip] {
-  position: relative;
-}
-
-[tooltip]::before {
+.tooltip {
   @include shadow;
   z-index: 1;
   pointer-events: none;
-  content: attr(tooltip);
-  left: 50%;
-  transform: translateX(-50%);
   background-color: #333;
   color: #fff;
   border: 0.5px solid hsl(0, 0%, 50%);
@@ -64,42 +57,18 @@ body {
   position: absolute;
   white-space: nowrap;
   opacity: 0;
-  transition: opacity 500ms ease-out;
-  top: 120%; // Put the tooltip under the element
+  transition: opacity 500ms ease-in;
+
+  position: absolute;
+  width: max-content;
+
+  left: 0;
+  top: 0;
 }
 
-[tooltip]:hover::before {
+.tooltip[tooltip-status=open] {
   opacity: 1;
   transition: opacity 500ms ease-in;
-}
-
-[no-hover][tooltip]::before {
-  opacity: 1;
-  transition: opacity 500ms ease-in;
-}
-
-[position="top"][tooltip]::before {
-  top: initial;
-  bottom: 120%;
-}
-
-[position="bottom"][tooltip]::before {
-  top: 120%;
-  bottom: initial;
-}
-
-[position="left"][tooltip]::before {
-  top: initial;
-  bottom: 0%;
-  left: initial;
-  right: 65%;
-}
-
-[position="right"][tooltip]::before {
-  top: initial;
-  bottom: 0%;
-  left: 150%;
-  right: initial;
 }
 
 .ib {

--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -45,35 +45,6 @@ body {
   }
 }
 
-@mixin tooltip {
-  @include shadow;
-  z-index: 1;
-  pointer-events: none;
-  background-color: #333;
-  color: #fff;
-  border: 0.5px solid hsl(0, 0%, 50%);
-  border-radius: 5px;
-  padding: 5px 10px;
-  position: absolute;
-  white-space: nowrap;
-  opacity: 0;
-  transition: opacity 500ms ease-in;
-}
-
-.tooltip {
-  @include tooltip;
-  position: absolute;
-  width: max-content;
-
-  left: 0;
-  top: 0;
-}
-
-.tooltip[tooltip-status=open] {
-  opacity: 1;
-  transition: opacity 500ms ease-in;
-}
-
 .ib {
   display: inline-block;
   padding: 1px;

--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -45,7 +45,7 @@ body {
   }
 }
 
-.tooltip {
+@mixin tooltip {
   @include shadow;
   z-index: 1;
   pointer-events: none;
@@ -58,7 +58,10 @@ body {
   white-space: nowrap;
   opacity: 0;
   transition: opacity 500ms ease-in;
+}
 
+.tooltip {
+  @include tooltip;
   position: absolute;
   width: max-content;
 

--- a/core/static/core/tooltips.scss
+++ b/core/static/core/tooltips.scss
@@ -1,0 +1,26 @@
+@import "colors";
+
+.tooltip {
+  @include shadow;
+  z-index: 1;
+  pointer-events: none;
+  background-color: #333;
+  color: #fff;
+  border: 0.5px solid hsl(0, 0%, 50%);
+  border-radius: 5px;
+  padding: 5px 10px;
+  position: absolute;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 500ms ease-out;
+  position: absolute;
+  width: max-content;
+
+  left: 0;
+  top: 0;
+}
+
+.tooltip[tooltip-status=open] {
+  opacity: 1;
+  transition: opacity 500ms ease-in;
+}

--- a/core/static/core/tooltips.scss
+++ b/core/static/core/tooltips.scss
@@ -13,8 +13,8 @@
   white-space: nowrap;
   opacity: 0;
   transition: opacity 500ms ease-out;
-  position: absolute;
-  width: max-content;
+
+  white-space: normal;
 
   left: 0;
   top: 0;

--- a/core/templates/core/base.jinja
+++ b/core/templates/core/base.jinja
@@ -24,6 +24,7 @@
       <script type="module" src="{{ static('bundled/alpine-index.js') }}"></script>
       <script type="module" src="{{ static('bundled/htmx-index.js') }}"></script>
       <script type="module" src="{{ static('bundled/country-flags-index.ts') }}"></script>
+      <script type="module" src="{{ static('bundled/core/tooltips-index.ts') }}"></script>
 
       <!-- Jquery declared here to be accessible in every django widgets -->
       <script src="{{ static('bundled/vendored/jquery.min.js') }}"></script>

--- a/core/templates/core/base.jinja
+++ b/core/templates/core/base.jinja
@@ -7,6 +7,7 @@
       <link rel="shortcut icon" href="{{ static('core/img/favicon.ico') }}">
       <link rel="stylesheet" href="{{ static('core/base.css') }}">
       <link rel="stylesheet" href="{{ static('core/style.scss') }}">
+      <link rel="stylesheet" href="{{ static('core/tooltips.scss') }}">
       <link rel="stylesheet" href="{{ static('core/markdown.scss') }}">
       <link rel="stylesheet" href="{{ static('core/header.scss') }}">
       <link rel="stylesheet" href="{{ static('core/navbar.scss') }}">

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@alpinejs/sort": "^3.14.7",
         "@arendjr/text-clipper": "npm:@jsr/arendjr__text-clipper@^3.0.0",
+        "@floating-ui/dom": "^1.6.13",
         "@fortawesome/fontawesome-free": "^6.6.0",
         "@fullcalendar/core": "^6.1.15",
         "@fullcalendar/daygrid": "^6.1.15",
@@ -2161,6 +2162,31 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "6.7.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@alpinejs/sort": "^3.14.7",
     "@arendjr/text-clipper": "npm:@jsr/arendjr__text-clipper@^3.0.0",
+    "@floating-ui/dom": "^1.6.13",
     "@fortawesome/fontawesome-free": "^6.6.0",
     "@fullcalendar/core": "^6.1.15",
     "@fullcalendar/daygrid": "^6.1.15",


### PR DESCRIPTION
Les tooltips qu'on avait elles étaient sympa mais elles clippent quand on sort de la zone de vue d'un élément.

Ici, je fait une petite lib js qui permet de faire des tooltips mais qui flottent au dessus de tout pour éviter ça.

L'api est la même mais avec plus d'options de positionnement.