### PR TITLE
Filter counters in ClubSellingView

### DIFF
--- a/club/tests/test_sales.py
+++ b/club/tests/test_sales.py
@@ -3,8 +3,11 @@ from django.test import Client
 from django.urls import reverse
 from model_bakery import baker
 
+from club.forms import SellingsForm
 from club.models import Club
 from core.models import User
+from counter.baker_recipes import product_recipe, sale_recipe
+from counter.models import Counter, Customer
 
 
 @pytest.mark.django_db
@@ -14,3 +17,22 @@ def test_sales_page_doesnt_crash(client: Client):
     client.force_login(admin)
     response = client.get(reverse("club:club_sellings", kwargs={"club_id": club.id}))
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_sales_form_counter_filter():
+    """Test that counters are properly filtered in SellingsForm"""
+    club = baker.make(Club)
+    counters = baker.make(
+        Counter, _quantity=5, _bulk_create=True, name=iter(["Z", "a", "B", "e", "f"])
+    )
+    counters[0].club = club
+    counters[0].save()
+    sale_recipe.make(
+        counter=counters[1], club=club, unit_price=0, customer=baker.make(Customer)
+    )
+    product_recipe.make(counters=[counters[2]], club=club)
+
+    form = SellingsForm(club)
+    form_counters = list(form.fields["counters"].queryset)
+    assert form_counters == [counters[1], counters[2], counters[0]]


### PR DESCRIPTION
Quand un club veut regarder les ventes, il n'a pas besoin de voir tous les 109 comptoirs existants (à l'heure où je fais cette PR).

A la place, on filtre pour afficher uniquement les comptoirs :

- Sur lesquels il y a eu des ventes de produits du club (donc ça marche même si le club lié au produit est modifié a posteriori)
- Ou bien sur lesquels il y a un produit du club (donc ça marche même si le produit existe, mais qu'il n'y a encore eu aucune vente)
- Ou bien qui appartiennent explicitement au club

