### PR TITLE
redirect `/user/me/*`

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -21,7 +21,6 @@
 # Place - Suite 330, Boston, MA 02111-1307, USA.
 #
 #
-
 from django.urls import path, re_path, register_converter
 from django.views.generic import RedirectView
 
@@ -68,6 +67,7 @@ from core.views import (
     UserGodfathersTreeView,
     UserGodfathersView,
     UserListView,
+    UserMeRedirect,
     UserMiniView,
     UserPreferencesView,
     UserStatsView,
@@ -141,6 +141,12 @@ urlpatterns = [
     ),
     # User views
     path("user/", UserListView.as_view(), name="user_list"),
+    path(
+        "user/me/<path:remaining_path>/",
+        UserMeRedirect.as_view(),
+        name="user_me_redirect_with_path",
+    ),
+    path("user/me/", UserMeRedirect.as_view(), name="user_me_redirect"),
     path("user/<int:user_id>/mini/", UserMiniView.as_view(), name="user_profile_mini"),
     path("user/<int:user_id>/", UserView.as_view(), name="user_profile"),
     path(

--- a/core/views/user.py
+++ b/core/views/user.py
@@ -48,6 +48,7 @@ from django.views.generic import (
     DeleteView,
     DetailView,
     ListView,
+    RedirectView,
     TemplateView,
 )
 from django.views.generic.dates import MonthMixin, YearMixin
@@ -180,6 +181,13 @@ class UserCreationView(FormView):
         user = form.save()
         login(self.request, user)
         return super().form_valid(form)
+
+
+class UserMeRedirect(LoginRequiredMixin, RedirectView):
+    def get_redirect_url(self, *args, **kwargs):
+        if remaining := kwargs.get("remaining_path"):
+            return f"/user/{self.request.user.id}/{remaining}/"
+        return f"/user/{self.request.user.id}/"
 
 
 class UserTabsMixin(TabedViewMixin):


### PR DESCRIPTION
Permet d'écrire l'url d'une page utilisateur sous la forme `/user/me/foo/bar/`. Dans ce cas, la redirection se fait vers `/user/{user_id}/foo/bar`, où `user_id` est l'id de l'utilisateur qui effectue la requête.

Par exemple, pour l'utilisateur `Subscribed User` des données de dev, `/user/me/` redirige vers `/user/3/` et `/user/me/account/` redirige vers `/user/3/account/`. 

Si l'utilisateur veut accéder à une ressource qui n'existe pas (comme `/user/me/coronasong/`, ou bien `/user/me/account/` alors qu'il n'est pas cotisant), la redirection vers la nouvelle url se fait quand même ; la seconde requête se charge de gérer le 404.