### PR TITLE
Notification improvements

### DIFF
--- a/com/models.py
+++ b/com/models.py
@@ -160,9 +160,12 @@ class News(models.Model):
         )
 
 
-def news_notification_callback(notif):
+def news_notification_callback(notif: Notification):
+    # the NewsDate linked to the News
+    # which creation triggered this callback may not exist yet,
+    # so it's important to filter by "not past date" rather than by "future date"
     count = News.objects.filter(
-        dates__start_date__gt=timezone.now(), is_published=False
+        ~Q(dates__start_date__gt=timezone.now()), is_published=False
     ).count()
     if count:
         notif.viewed = False

--- a/com/tests/test_notifications.py
+++ b/com/tests/test_notifications.py
@@ -1,0 +1,23 @@
+import pytest
+from django.conf import settings
+from model_bakery import baker
+
+from com.models import News
+from core.models import Group, Notification, User
+
+
+@pytest.mark.django_db
+def test_notification_created():
+    com_admin_group = Group.objects.get(pk=settings.SITH_GROUP_COM_ADMIN_ID)
+    com_admin_group.users.all().delete()
+    Notification.objects.all().delete()
+    com_admin = baker.make(User, groups=[com_admin_group])
+    for i in range(2):
+        # news notifications are permanent, so the notification created
+        # during the first iteration should be reused during the second one.
+        baker.make(News)
+        notifications = list(Notification.objects.all())
+        assert len(notifications) == 1
+        assert notifications[0].user == com_admin
+        assert notifications[0].type == "NEWS_MODERATION"
+        assert notifications[0].param == str(i + 1)


### PR DESCRIPTION
Les notifications permanentes marchaient pas bien. Celles pour la com captaient une nouvelle de pas assez, et la première nouvelle permanente pour un utilisateur n'appelait pas son callback (ce qu'il fait qu'il se retrouvait avec un blanc dans son message)