### PR TITLE
Disable mouse click on navbar for desktop

### DIFF
--- a/core/templates/core/base.jinja
+++ b/core/templates/core/base.jinja
@@ -124,18 +124,28 @@
     {% block script %}
       <script>
         const menuItems = document.querySelectorAll(".navbar details[name='navbar'].menu");
-        const isMobile = () => {
+        const isDesktop = () => {
           return window.innerWidth >= 500;
         }
         for (const item of menuItems){
           item.addEventListener("mouseover", () => {
-            if (isMobile()){
+            if (isDesktop()){
               item.setAttribute("open", "");
             }
           })
           item.addEventListener("mouseout", () => {
-            if (isMobile()){
+            if (isDesktop()){
               item.removeAttribute("open");
+            }
+          })
+          item.addEventListener("click", (event) => {
+            // Ignore keyboard clicks
+            if (event.detail === 0){
+              return;
+            }
+
+            if (isDesktop()){
+              event.preventDefault();
             }
           })
         }


### PR DESCRIPTION
On a un bug nul où si tu click dans la barre de navigation sur les menus déroulants, ça les ferme.
J'ai rajouté un truc où je désactive ça en mode desktop.

Aussi, j'ai renommé isMobile en isDesktop parce que j'avais inversé la condition à l'intérieur et du coup c'était faux.