### PR TITLE
fix: documentation CI/CD

### DIFF
--- a/.github/actions/setup_project/action.yml
+++ b/.github/actions/setup_project/action.yml
@@ -1,15 +1,24 @@
 name: "Setup project"
 description: "Setup Python and Poetry"
+inputs:
+  full:
+    description: > 
+      If true, do a full setup, else install
+      only python, uv and non-xapian python deps
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
     - name: Install apt packages
+      if: ${{ inputs.full == 'true' }}
       uses: awalsh128/cache-apt-pkgs-action@v1.4.3
       with:
         packages: gettext
         version: 1.0  # increment to reset cache
 
     - name: Install Redis
+      if: ${{ inputs.full == 'true' }}
       uses: shogo82148/actions-setup-redis@v1
       with:
         redis-version: "7.x"
@@ -37,15 +46,20 @@ runs:
       shell: bash
 
     - name: Install Xapian
+      if: ${{ inputs.full == 'true' }}
       run: uv run ./manage.py install_xapian
       shell: bash
 
+    # compiling xapian accounts for almost the entirety of the virtualenv setup,
+    # so we save the virtual environment only on workflows where it has been installed
     - name: Save cached virtualenv
+      if: ${{ inputs.full == 'true' }}
       uses: actions/cache/save@v4
       with:
         key: venv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('pyproject.toml') }}-${{ env.CACHE_SUFFIX }}
         path: .venv
 
     - name: Compile gettext messages
+      if: ${{ inputs.full == 'true' }}
       run: uv run ./manage.py compilemessages
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
       - uses: ./.github/actions/setup_project
+        with:
+          full: true
         env:
           # To avoid race conditions on environment cache
           CACHE_SUFFIX: ${{ matrix.pytest-mark }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -2,11 +2,7 @@ name: deploy_docs
 on:
   push:
     branches:
-      - master
-env:
-  SECRET_KEY: notTheRealOne
-  DATABASE_URL: sqlite:///db.sqlite3
-  CACHE_URL: redis://127.0.0.1:6379/0
+      - taiste
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
La doc compilait plus, parce que des variables d'environnement n'étaient pas renseignées dans le fichier du workflow.
J'ai réparé en allégeant ce dernier pour que la variable en question ne soit plus nécessaire.

J'ai aussi changé le moment où la doc est redéployée, pour que ça arrive aux push sur taiste, plutôt que sur master.