### PR TITLE
Api fixes

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -2,7 +2,7 @@ from ninja_extra import NinjaExtraAPI
 
 api = NinjaExtraAPI(
     title="PICON",
-    description="Portail Interaction de Communication avec les Services Étudiants",
+    description="Portail Interactif de Communication avec les Services Étudiants",
     version="0.2.0",
     urls_namespace="api",
     csrf=True,

--- a/club/api.py
+++ b/club/api.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 
 from annotated_types import MinLen
+from django.db.models import Prefetch
 from ninja.security import SessionAuth
 from ninja_extra import ControllerBase, api_controller, paginate, route
 from ninja_extra.pagination import PageNumberPaginationExtra
@@ -8,7 +9,7 @@ from ninja_extra.schemas import PaginatedResponseSchema
 
 from api.auth import ApiKeyAuth
 from api.permissions import CanAccessLookup, HasPerm
-from club.models import Club
+from club.models import Club, Membership
 from club.schemas import ClubSchema, SimpleClubSchema
 
 
@@ -33,6 +34,9 @@ class ClubController(ControllerBase):
         url_name="fetch_club",
     )
     def fetch_club(self, club_id: int):
+        prefetch = Prefetch(
+            "members", queryset=Membership.objects.ongoing().select_related("user")
+        )
         return self.get_object_or_exception(
-            Club.objects.prefetch_related("members", "members__user"), id=club_id
+            Club.objects.prefetch_related(prefetch), id=club_id
         )

--- a/club/tests/test_club_controller.py
+++ b/club/tests/test_club_controller.py
@@ -1,7 +1,10 @@
+from datetime import date, timedelta
+
 import pytest
 from django.test import Client
 from django.urls import reverse
 from model_bakery import baker
+from model_bakery.recipe import Recipe
 from pytest_django.asserts import assertNumQueries
 
 from club.models import Club, Membership
@@ -9,13 +12,32 @@ from core.baker_recipes import subscriber_user
 
 
 @pytest.mark.django_db
-def test_fetch_club(client: Client):
-    club = baker.make(Club)
-    baker.make(Membership, club=club, _quantity=10, _bulk_create=True)
-    user = subscriber_user.make()
-    client.force_login(user)
-    with assertNumQueries(7):
-        # - 4 queries for authentication
-        # - 3 queries for the actual data
+class TestFetchClub:
+    @pytest.fixture()
+    def club(self):
+        club = baker.make(Club)
+        last_month = date.today() - timedelta(days=30)
+        yesterday = date.today() - timedelta(days=1)
+        membership_recipe = Recipe(Membership, club=club, start_date=last_month)
+        membership_recipe.make(end_date=None, _quantity=10, _bulk_create=True)
+        membership_recipe.make(end_date=yesterday, _quantity=10, _bulk_create=True)
+        return club
+
+    def test_fetch_club_members(self, client: Client, club: Club):
+        user = subscriber_user.make()
+        client.force_login(user)
         res = client.get(reverse("api:fetch_club", kwargs={"club_id": club.id}))
         assert res.status_code == 200
+        member_ids = {member["user"]["id"] for member in res.json()["members"]}
+        assert member_ids == set(
+            club.members.ongoing().values_list("user_id", flat=True)
+        )
+
+    def test_fetch_club_nb_queries(self, client: Client, club: Club):
+        user = subscriber_user.make()
+        client.force_login(user)
+        with assertNumQueries(6):
+            # - 4 queries for authentication
+            # - 2 queries for the actual data
+            res = client.get(reverse("api:fetch_club", kwargs={"club_id": club.id}))
+            assert res.status_code == 200


### PR DESCRIPTION
Typo dans la description de l'API

La route qui retourne les détails d'un club donnait tous les membres présents comme passés, plutôt que juste les membres actifs.