### PR TITLE
fix: api title typo (again)

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -2,7 +2,7 @@ from ninja_extra import NinjaExtraAPI
 
 api = NinjaExtraAPI(
     title="PICON",
-    description="Portail Interactif de Communication avec les Services Étudiants",
+    description="Portail Interactif de Communication avec les Outils Numériques",
     version="0.2.0",
     urls_namespace="api",
     csrf=True,


### PR DESCRIPTION
J'ai mélangé Libre Outil Universitaire d'Interaction avec les Services Etudiants (LOUISE) et Portail Interactif de Communication avec les Outils Numériques (PICON), quand j'ai renommé l'API. Donc l'acronyme donnait PICSE. Meh. 