### PR TITLE
Add zoom controls to family graph

### DIFF
--- a/core/static/bundled/user/family-graph-index.ts
+++ b/core/static/bundled/user/family-graph-index.ts
@@ -287,7 +287,6 @@ document.addEventListener("alpine:init", () => {
         config.activeUser,
       );
       this.graph.userZoomingEnabled(this.isZoomEnabled);
-      this.$refs.graph.prepend(this.$refs.zoomControl);
       this.loading = false;
     },
   }));

--- a/core/static/bundled/user/family-graph-index.ts
+++ b/core/static/bundled/user/family-graph-index.ts
@@ -287,6 +287,7 @@ document.addEventListener("alpine:init", () => {
         config.activeUser,
       );
       this.graph.userZoomingEnabled(this.isZoomEnabled);
+      this.$refs.graph.prepend(this.$refs.zoomControl);
       this.loading = false;
     },
   }));

--- a/core/static/bundled/user/family-graph-index.ts
+++ b/core/static/bundled/user/family-graph-index.ts
@@ -5,7 +5,7 @@ import cytoscape, {
   type Singular,
 } from "cytoscape";
 import cxtmenu from "cytoscape-cxtmenu";
-import klay from "cytoscape-klay";
+import klay, { type KlayLayoutOptions } from "cytoscape-klay";
 import { type UserProfileSchema, familyGetFamilyGraph } from "#openapi";
 
 cytoscape.use(klay);
@@ -100,9 +100,9 @@ function createGraph(container: HTMLDivElement, data: GraphData, activeUserId: n
       {
         selector: ".not-traversed",
         style: {
-          "line-opacity": "0.5",
-          "background-opacity": "0.5",
-          "background-image-opacity": "0.5",
+          "line-opacity": 0.5,
+          "background-opacity": 0.5,
+          "background-image-opacity": 0.5,
         },
       },
     ],
@@ -116,21 +116,14 @@ function createGraph(container: HTMLDivElement, data: GraphData, activeUserId: n
         nodePlacement: "INTERACTIVE",
         layoutHierarchy: true,
       },
-    },
+    } as KlayLayoutOptions,
   });
   const activeUser = cy
     .getElementById(activeUserId.toString())
     .style("shape", "rectangle");
   /* Reset graph */
   const resetGraph = () => {
-    cy.elements(((element: Singular) => {
-      if (element.hasClass("traversed")) {
-        element.removeClass("traversed");
-      }
-      if (element.hasClass("not-traversed")) {
-        element.removeClass("not-traversed");
-      }
-    }) as unknown as string);
+    cy.elements().removeClass("traversed not-traversed");
   };
 
   const onNodeTap = (el: Singular) => {
@@ -139,9 +132,7 @@ function createGraph(container: HTMLDivElement, data: GraphData, activeUserId: n
     if (el === activeUser) {
       return;
     }
-    cy.elements(((element: Singular) => {
-      element.addClass("not-traversed");
-    }) as unknown as string);
+    cy.elements().addClass("not-traversed");
 
     for (const traversed of cy.elements().aStar({
       root: el,
@@ -188,9 +179,12 @@ function createGraph(container: HTMLDivElement, data: GraphData, activeUserId: n
 }
 
 interface FamilyGraphConfig {
-  activeUser: number; // activeUser Id of the user to fetch the tree from
-  depthMin: number; // depthMin Minimum tree depth for godfathers and godchildren
-  depthMax: number; // depthMax Maximum tree depth for godfathers and godchildren
+  /**Id of the user to fetch the tree from*/
+  activeUser: number;
+  /**Minimum tree depth for godfathers and godchildren*/
+  depthMin: number;
+  /**Maximum tree depth for godfathers and godchildren*/
+  depthMax: number;
 }
 
 document.addEventListener("alpine:init", () => {

--- a/core/static/bundled/user/family-graph-index.ts
+++ b/core/static/bundled/user/family-graph-index.ts
@@ -16,6 +16,10 @@ type GraphData = (
   | { data: { source: number; target: number } }
 )[];
 
+function isMobile() {
+  return window.innerWidth < 500;
+}
+
 async function getGraphData(
   userId: number,
   godfathersDepth: number,
@@ -151,7 +155,6 @@ function createGraph(container: HTMLDivElement, data: GraphData, activeUserId: n
   cy.on("tap", "node", (tapped) => {
     onNodeTap(tapped.target);
   });
-  cy.zoomingEnabled(false);
 
   /* Add context menu */
   cy.cxtmenu({
@@ -200,6 +203,7 @@ document.addEventListener("alpine:init", () => {
     reverse: initialUrlParams.get("reverse")?.toLowerCase?.() === "true",
     graph: undefined as cytoscape.Core,
     graphData: {},
+    isZoomEnabled: !isMobile(),
 
     getInitialDepth(prop: string) {
       const value = Number.parseInt(initialUrlParams.get(prop));
@@ -234,6 +238,9 @@ document.addEventListener("alpine:init", () => {
         if (this.reverse) {
           await this.reverseGraph();
         }
+      });
+      this.$watch("isZoomEnabled", () => {
+        this.graph.userZoomingEnabled(this.isZoomEnabled);
       });
       await this.fetchGraphData();
     },
@@ -279,6 +286,7 @@ document.addEventListener("alpine:init", () => {
         this.graphData,
         config.activeUser,
       );
+      this.graph.userZoomingEnabled(this.isZoomEnabled);
       this.loading = false;
     },
   }));

--- a/core/static/user/user_godfathers.scss
+++ b/core/static/user/user_godfathers.scss
@@ -2,6 +2,12 @@
   width: 100%;
   height: 70vh;
   display: block;
+  overflow: clip;
+}
+
+.zoom-control {
+  float: right;
+  margin-right: 10px;
 }
 
 .graph-toolbar {
@@ -12,7 +18,7 @@
   justify-content: space-around;
   gap: 30px;
 
-  .toolbar-column{
+  .toolbar-column {
     display: flex;
     flex-direction: column;
     gap: 20px;
@@ -34,31 +40,38 @@
 
     .depth-choice {
       white-space: nowrap;
+
       input[type="number"] {
         -webkit-appearance: textfield;
         -moz-appearance: textfield;
         appearance: textfield;
+
         &::-webkit-inner-spin-button,
         &::-webkit-outer-spin-button {
           -webkit-appearance: none;
         }
       }
+
       button {
         background: none;
-        & > .fa {
+
+        &>.fa {
           border-radius: 50%;
           font-size: 12px;
           padding: 5px;
         }
-        &:enabled > .fa {
+
+        &:enabled>.fa {
           background-color: #354a5f;
           color: white;
         }
-        &:enabled:hover > .fa {
+
+        &:enabled:hover>.fa {
           color: white;
           background-color: #35405f; // just a bit darker
         }
-        &:disabled > .fa {
+
+        &:disabled>.fa {
           background-color: gray;
           color: white;
         }
@@ -74,6 +87,7 @@
   @media screen and (max-width: 500px) {
     flex-direction: column;
     gap: 20px;
+
     .toolbar-column {
       min-width: 100%;
     }
@@ -87,14 +101,16 @@
   padding: 10px;
   box-sizing: border-box;
 
-  > form {
+  >form {
     margin: 0;
   }
 }
+
 #family-tree-link {
   display: inline-block;
   margin-top: 10px;
   text-align: center;
+
   @media (min-width: 450px) {
     margin-right: auto;
   }
@@ -122,10 +138,10 @@
     width: 100%;
   }
 
-  > div.mini_profile_link {
+  >div.mini_profile_link {
     position: relative;
 
-    > a {
+    >a {
       &.mini_profile_link {
         display: flex;
         flex-direction: column;
@@ -140,7 +156,7 @@
           max-height: 65px;
         }
 
-        > span {
+        >span {
           height: 150px;
           width: 100%;
 
@@ -149,7 +165,7 @@
             width: 80px;
           }
 
-          > img {
+          >img {
             width: 100%;
             max-width: 100%;
             max-height: 100%;
@@ -163,7 +179,7 @@
           }
         }
 
-        > em {
+        >em {
           box-sizing: border-box;
           padding: 0 5px;
           text-align: center;
@@ -195,7 +211,7 @@
     }
   }
 
-  > a.mini_profile_link {
+  >a.mini_profile_link {
     display: none;
   }
 }

--- a/core/static/user/user_godfathers.scss
+++ b/core/static/user/user_godfathers.scss
@@ -2,12 +2,12 @@
   width: 100%;
   height: 70vh;
   display: block;
-  overflow: clip;
 }
 
 .zoom-control {
-  float: right;
   margin-right: 10px;
+  display: flex;
+  justify-content: right;
 }
 
 .graph-toolbar {

--- a/core/templates/core/user_godfathers_tree.jinja
+++ b/core/templates/core/user_godfathers_tree.jinja
@@ -77,6 +77,7 @@
               ></i></button>
           </span>
         </div>
+
       </div>
 
       <div class="toolbar-column">
@@ -91,6 +92,31 @@
           <i class="fa fa-camera"></i>
           {% trans %}Save{% endtrans %}
         </button>
+
+        <div class="toolbar-input">
+          <button
+            @click="() => graph.zoom(graph.zoom() + 1)"
+          >
+            <i class="fa-solid fa-magnifying-glass-plus"></i>
+          </button>
+          <button
+            @click="() => graph.zoom(graph.zoom() - 1)"
+          >
+            <i class="fa-solid fa-magnifying-glass-minus"></i>
+          </button>
+          <button
+            x-show="isZoomEnabled"
+            @click="() => isZoomEnabled = false"
+          >
+            <i class="fa-solid fa-unlock"></i>
+          </button>
+          <button
+            x-show="!isZoomEnabled"
+            @click="() => isZoomEnabled = true"
+          >
+            <i class="fa-solid fa-lock"></i>
+          </button>
+        </div>
       </div>
     </div>
     <div x-ref="graph" class="graph"></div>

--- a/core/templates/core/user_godfathers_tree.jinja
+++ b/core/templates/core/user_godfathers_tree.jinja
@@ -97,11 +97,13 @@
     <div class="zoom-control" x-ref="zoomControl">
       <button
         @click="graph.zoom(graph.zoom() + 1)"
+        :disabled="!isZoomEnabled"
       >
         <i class="fa-solid fa-magnifying-glass-plus"></i>
       </button>
       <button
         @click="graph.zoom(graph.zoom() - 1)"
+        :disabled="!isZoomEnabled"
       >
         <i class="fa-solid fa-magnifying-glass-minus"></i>
       </button>

--- a/core/templates/core/user_godfathers_tree.jinja
+++ b/core/templates/core/user_godfathers_tree.jinja
@@ -77,7 +77,6 @@
               ></i></button>
           </span>
         </div>
-
       </div>
 
       <div class="toolbar-column">
@@ -92,33 +91,34 @@
           <i class="fa fa-camera"></i>
           {% trans %}Save{% endtrans %}
         </button>
-
-        <div class="toolbar-input">
-          <button
-            @click="() => graph.zoom(graph.zoom() + 1)"
-          >
-            <i class="fa-solid fa-magnifying-glass-plus"></i>
-          </button>
-          <button
-            @click="() => graph.zoom(graph.zoom() - 1)"
-          >
-            <i class="fa-solid fa-magnifying-glass-minus"></i>
-          </button>
-          <button
-            x-show="isZoomEnabled"
-            @click="() => isZoomEnabled = false"
-          >
-            <i class="fa-solid fa-unlock"></i>
-          </button>
-          <button
-            x-show="!isZoomEnabled"
-            @click="() => isZoomEnabled = true"
-          >
-            <i class="fa-solid fa-lock"></i>
-          </button>
-        </div>
       </div>
     </div>
+
+    <div class="zoom-control" x-ref="zoomControl" x-show="graph !== undefined">
+      <button
+        @click="() => graph.zoom(graph.zoom() + 1)"
+      >
+        <i class="fa-solid fa-magnifying-glass-plus"></i>
+      </button>
+      <button
+        @click="() => graph.zoom(graph.zoom() - 1)"
+      >
+        <i class="fa-solid fa-magnifying-glass-minus"></i>
+      </button>
+      <button
+        x-show="isZoomEnabled"
+        @click="() => isZoomEnabled = false"
+      >
+        <i class="fa-solid fa-unlock"></i>
+      </button>
+      <button
+        x-show="!isZoomEnabled"
+        @click="() => isZoomEnabled = true"
+      >
+        <i class="fa-solid fa-lock"></i>
+      </button>
+    </div>
+
     <div x-ref="graph" class="graph"></div>
   </div>
 

--- a/core/templates/core/user_godfathers_tree.jinja
+++ b/core/templates/core/user_godfathers_tree.jinja
@@ -94,7 +94,7 @@
       </div>
     </div>
 
-    <div class="zoom-control" x-ref="zoomControl" x-show="graph !== undefined">
+    <div class="zoom-control" x-ref="zoomControl">
       <button
         @click="graph.zoom(graph.zoom() + 1)"
       >

--- a/core/templates/core/user_godfathers_tree.jinja
+++ b/core/templates/core/user_godfathers_tree.jinja
@@ -96,24 +96,24 @@
 
     <div class="zoom-control" x-ref="zoomControl" x-show="graph !== undefined">
       <button
-        @click="() => graph.zoom(graph.zoom() + 1)"
+        @click="graph.zoom(graph.zoom() + 1)"
       >
         <i class="fa-solid fa-magnifying-glass-plus"></i>
       </button>
       <button
-        @click="() => graph.zoom(graph.zoom() - 1)"
+        @click="graph.zoom(graph.zoom() - 1)"
       >
         <i class="fa-solid fa-magnifying-glass-minus"></i>
       </button>
       <button
         x-show="isZoomEnabled"
-        @click="() => isZoomEnabled = false"
+        @click="isZoomEnabled = false"
       >
         <i class="fa-solid fa-unlock"></i>
       </button>
       <button
         x-show="!isZoomEnabled"
-        @click="() => isZoomEnabled = true"
+        @click="isZoomEnabled = true"
       >
         <i class="fa-solid fa-lock"></i>
       </button>

--- a/core/templates/core/user_godfathers_tree.jinja
+++ b/core/templates/core/user_godfathers_tree.jinja
@@ -7,7 +7,7 @@
 {%- endblock -%}
 
 {% block additional_js %}
-  <script type="module" src="{{ static("bundled/user/family-graph-index.js") }}"></script>
+  <script type="module" src="{{ static("bundled/user/family-graph-index.ts") }}"></script>
 {% endblock %}
 
 {% block title %}
@@ -15,7 +15,14 @@
 {% endblock %}
 
 {% block content %}
-  <div x-data="graph" :aria-busy="loading">
+  <div
+    x-data="graph({
+            activeUser: {{ object.id }},
+            depthMin: {{ depth_min }},
+            depthMax: {{ depth_max }},
+            })"
+    :aria-busy="loading"
+  >
     <div class="graph-toolbar">
       <div class="toolbar-column">
         <div class="toolbar-input">
@@ -89,14 +96,5 @@
     <div x-ref="graph" class="graph"></div>
   </div>
 
-  <script>
-    window.addEventListener("DOMContentLoaded", () => {
-      loadFamilyGraph({
-        activeUser: {{ object.id }},
-        depthMin: {{ depth_min }},
-        depthMax: {{ depth_max }},
-      });
-    });
-  </script>
 {% endblock %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,8 @@
         "@hey-api/openapi-ts": "^0.73.0",
         "@rollup/plugin-inject": "^5.0.5",
         "@types/alpinejs": "^3.13.10",
+        "@types/cytoscape-cxtmenu": "^3.4.4",
+        "@types/cytoscape-klay": "^3.1.4",
         "@types/jquery": "^3.5.31",
         "vite": "^6.2.5",
         "vite-bundle-visualizer": "^1.2.1",
@@ -2817,6 +2819,33 @@
       "license": "MIT",
       "dependencies": {
         "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/cytoscape": {
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.21.9.tgz",
+      "integrity": "sha512-JyrG4tllI6jvuISPjHK9j2Xv/LTbnLekLke5otGStjFluIyA9JjgnvgZrSBsp8cEDpiTjwgZUZwpPv8TSBcoLw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/cytoscape-cxtmenu": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape-cxtmenu/-/cytoscape-cxtmenu-3.4.4.tgz",
+      "integrity": "sha512-cuv+IdbKekswDRBIrHn97IYOzWS2/UjVr0kDIHCOYvqWy3iZkuGGM4qmHNPQ+63Dn7JgtmD0l3MKW1moyhoaKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cytoscape": "*"
+      }
+    },
+    "node_modules/@types/cytoscape-klay": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape-klay/-/cytoscape-klay-3.1.4.tgz",
+      "integrity": "sha512-H+tIadpcVjmDGWKFUfibwzIpH/kddfwAFsuhPparjiC+bWBm+MeNqIwwY+19ofkJZWcqWqZL6Jp8lkp+sP8Aig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cytoscape": "*"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@rollup/plugin-inject": "^5.0.5",
     "@types/alpinejs": "^3.13.10",
     "@types/jquery": "^3.5.31",
+    "@types/cytoscape-cxtmenu": "^3.4.4",
+    "@types/cytoscape-klay": "^3.1.4",
     "vite": "^6.2.5",
     "vite-bundle-visualizer": "^1.2.1",
     "vite-plugin-static-copy": "^3.0.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1852,7 +1852,7 @@ dev = [
     { name = "ipython", specifier = ">=9.0.2,<10.0.0" },
     { name = "pre-commit", specifier = ">=4.1.0,<5.0.0" },
     { name = "rjsmin", specifier = ">=1.2.4,<2.0.0" },
-    { name = "ruff", specifier = ">=0.11.11,<1.0.0" },
+    { name = "ruff", specifier = ">=0.11.13,<1.0.0" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6.1,<2.0.0" },


### PR DESCRIPTION
Un ami dont je tairais le nom ici est très mécontent de ne pas pouvoir voir sa famille entière sur l'arbre des familles.

Il m'a dit, je cite

> j'arrive pas a avoir ma famille au complet
> imagine tu rentee chez toi et tu ne retrouve que la moitié de ton chat
> c'est horrible

Au vu de ces propos qui, je suis certain, dépassaient sa pensée, j'ai ajouté des boutons de contrôle du zoom.

Changements:
* Activer/désactiver le zoom
* Le zoom est désactivé sur mobile par défaut
* Zoomer/dézoomer avec des boutons
* Le tout a été convertit en typescript
* 
![image](https://github.com/user-attachments/assets/14070383-3eb5-4399-a68c-9bf04ba685ff)
![image](https://github.com/user-attachments/assets/eca5faa1-794a-4f73-bba1-32454bf83600)
