### PR TITLE
fix: xapian compilation flags

### DIFF
--- a/core/management/commands/install_xapian.sh
+++ b/core/management/commands/install_xapian.sh
@@ -4,13 +4,13 @@
 VERSION="$1"
 
 # Cleanup env vars for auto discovery mechanism
-export CPATH=
-export LIBRARY_PATH=
-export CFLAGS=
-export LDFLAGS=
-export CCFLAGS=
-export CXXFLAGS=
-export CPPFLAGS=
+unset CPATH
+unset LIBRARY_PATH
+unset CFLAGS
+unset LDFLAGS
+unset CCFLAGS
+unset CXXFLAGS
+unset CPPFLAGS
 
 # prepare
 rm -rf "$VIRTUAL_ENV/packages"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ docs = [
 default-groups = ["dev", "tests", "docs"]
 
 [tool.xapian]
-version = "1.4.25"
+version = "1.4.29"
 
 [tool.ruff]
 output-format = "concise" # makes ruff error logs easier to read


### PR DESCRIPTION
On mettait mal en place les flags de compilation, ce qui fait qu'on compilait sans optimiser le binaire.

### Résultat sur les données de dev

#### Recherche d'utilisateur

Avant :
```python
>>> %timeit list(
    SearchQuerySet().models(User).autocomplete(auto=slugify("Géra")).values("id")
)
1.84 ms ± 8.55 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
Après :
```python
>>> %timeit list(
    SearchQuerySet().models(User).autocomplete(auto=slugify("Géra")).values("id")
)
507 µs ± 4.93 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

Résultat : perfs x3.63 (sur un jeu de 900 utilisateurs)

#### Recherche de message sur le forum

Avant :
```python
>>> %timeit list(
    SearchQuerySet().models(ForumMessage).autocomplete(auto=slugify("Appel")).values("id")
)
170 ms ± 1.97 per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
Après :
```python
>>> %timeit list(
    SearchQuerySet().models(ForumMessage).autocomplete(auto=slugify("Appel")).values("id")
)
21.3 ms ± 203 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
Résultat : perfs x8 (sur un jeu de 9000 messages)