### PR TITLE
fix footer alignment on small screens

### DIFF
--- a/core/static/core/footer.scss
+++ b/core/static/core/footer.scss
@@ -2,6 +2,10 @@
 @import "devices";
 
 footer.bottom-links {
+  >section>a {
+    text-align: center;
+  }
+
   @media (max-width: $small-devices) {
     margin-top: 0.6em;
     padding: 1.25em;


### PR DESCRIPTION
Petit soucis sur le footer où les liens étaient mal alignés sur mobile, j'avais pas essayé avec un écran assez petit :/

Avant
<img width="386" alt="image" src="https://github.com/user-attachments/assets/a37ce893-7f98-45bb-bd30-ce3056df61a8" />

Après
<img width="363" alt="image" src="https://github.com/user-attachments/assets/da3833c0-2d19-4ec4-b979-f6a8d4a4869f" />

J'ai testé directement sur téléphone aussi, pour être certain
