### PR TITLE
fix old subscribers group attribution

### DIFF
--- a/subscription/models.py
+++ b/subscription/models.py
@@ -18,7 +18,6 @@ from datetime import date, timedelta
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.contrib.auth.forms import PasswordResetForm
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
@@ -73,23 +72,19 @@ class Subscription(models.Model):
             return f"No user - {self.pk}"
 
     def save(self, *args, **kwargs):
-        super().save()
         from counter.models import Customer
 
-        _, account_created = Customer.get_or_create(self.member)
-        if account_created:
+        if not self.member.was_subscribed:
+            # This is the first ever subscription for this user
+            customer, _ = Customer.get_or_create(self.member)
             # Someone who subscribed once will be considered forever
             # as an old subscriber.
             self.member.groups.add(settings.SITH_GROUP_OLD_SUBSCRIBERS_ID)
-            form = PasswordResetForm({"email": self.member.email})
-            if form.is_valid():
-                form.save(
-                    use_https=True,
-                    email_template_name="core/new_user_email.jinja",
-                    subject_template_name="core/new_user_email_subject.jinja",
-                    from_email="ae@utbm.fr",
-                )
-        self.member.make_home()
+            self.member.make_home()
+            # now that the user is an old subscriber, change the cached
+            # property accordingly
+            self.member.__dict__["was_subscribed"] = True
+        super().save()
 
     def get_absolute_url(self):
         return reverse("core:user_edit", kwargs={"user_id": self.member_id})


### PR DESCRIPTION
Si un utilisateur faisait sa première cotisation alors qu'il avait déjà un compte AE (par exemple, en effectuant un achat sur l'eboutic avant sa cotisation), alors il pouvait se retrouver hors du groupe Anciens cotisants.

J'ai aussi bougé le code qui gère l'envoi du mail à la première cotisation. Avant, on l'envoyait à chaque première cotisation, ce qui veut dire qu'un utilisateur qui avait déjà un compte utilisateur et qui faisait sa première cotisation recevait le mail, alors qu'on voudrait l'envoyer uniquement à ceux dont le compte est créé automatiquement avec la cotisation, afin de leur dire comment y accéder. Maintenant, c'est le fragment de création des cotisations pour des nouveaux utilisateurs qui gère l'envoi du mail.