### PR TITLE
Subscription birthday

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -25,6 +25,7 @@ from core.schemas import (
     UserFamilySchema,
     UserFilterSchema,
     UserProfileSchema,
+    UserSchema,
 )
 from core.templatetags.renderer import markdown
 
@@ -69,16 +70,22 @@ class MailingListController(ControllerBase):
         return data
 
 
-@api_controller("/user", permissions=[CanAccessLookup])
+@api_controller("/user")
 class UserController(ControllerBase):
-    @route.get("", response=list[UserProfileSchema])
+    @route.get("", response=list[UserProfileSchema], permissions=[CanAccessLookup])
     def fetch_profiles(self, pks: Query[set[int]]):
         return User.objects.filter(pk__in=pks)
+
+    @route.get("/{int:user_id}", response=UserSchema, permissions=[CanView])
+    def fetch_user(self, user_id: int):
+        """Fetch a single user"""
+        return self.get_object_or_exception(User, id=user_id)
 
     @route.get(
         "/search",
         response=PaginatedResponseSchema[UserProfileSchema],
         url_name="search_users",
+        permissions=[CanAccessLookup],
     )
     @paginate(PageNumberPaginationExtra, page_size=20)
     def search_users(self, filters: Query[UserFilterSchema]):

--- a/core/management/commands/populate_more.py
+++ b/core/management/commands/populate_more.py
@@ -94,7 +94,11 @@ class Command(BaseCommand):
                 username=self.faker.user_name(),
                 first_name=self.faker.first_name(),
                 last_name=self.faker.last_name(),
-                date_of_birth=self.faker.date_of_birth(minimum_age=15, maximum_age=25),
+                date_of_birth=(
+                    None
+                    if random.random() < 0.2
+                    else self.faker.date_of_birth(minimum_age=15, maximum_age=25)
+                ),
                 email=self.faker.email(),
                 phone=self.faker.phone_number(),
                 address=self.faker.address(),

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -34,6 +34,22 @@ class SimpleUserSchema(ModelSchema):
         fields = ["id", "nick_name", "first_name", "last_name"]
 
 
+class UserSchema(ModelSchema):
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "nick_name",
+            "first_name",
+            "last_name",
+            "date_of_birth",
+            "email",
+            "role",
+            "quote",
+            "promo",
+        ]
+
+
 class UserProfileSchema(ModelSchema):
     """The necessary information to show a user profile"""
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-01 18:18+0200\n"
+"POT-Creation-Date: 2025-09-02 15:56+0200\n"
 "PO-Revision-Date: 2016-07-18\n"
 "Last-Translator: Maréchal <thomas.girod@utbm.fr\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -5135,6 +5135,10 @@ msgstr "Tee-shirt AE"
 msgid "A user with that email address already exists"
 msgstr "Un utilisateur avec cette adresse email existe déjà"
 
+#: subscription/forms.py
+msgid "This user didn't fill its birthdate yet."
+msgstr "Cet utilisateur n'a pas encore renseigné sa date de naissance"
+
 #: subscription/models.py
 msgid "Bad subscription type"
 msgstr "Mauvais type de cotisation"
@@ -5174,7 +5178,7 @@ msgid ""
 "%(user)s received its new %(type)s subscription. It will be active until "
 "%(end)s included."
 msgstr ""
-"%(user)s a reçu sa nouvelle cotisaton %(type)s. Elle sert active jusqu'au "
+"%(user)s a reçu sa nouvelle cotisaton %(type)s. Elle sera active jusqu'au "
 "%(end)s inclu."
 
 #: subscription/templates/subscription/fragments/creation_success.jinja

--- a/subscription/forms.py
+++ b/subscription/forms.py
@@ -158,9 +158,11 @@ class SubscriptionExistingUserForm(SubscriptionForm):
         self.fields["birthdate"].required = True
         if not initial:
             return
-        member = initial.get("member")
-        if member:
-            member = User.objects.filter(id=member).first()
+        member: str | None = initial.get("member")
+        if member and member.isdigit():
+            member: User | None = User.objects.filter(id=int(member)).first()
+        else:
+            member = None
         if member and member.date_of_birth:
             # if there is an initial member with a birthdate,
             # there is no need to ask this to the user
@@ -178,7 +180,7 @@ class SubscriptionExistingUserForm(SubscriptionForm):
             return super().save(*args, **kwargs)
         if (
             self.cleaned_data["birthdate"] is not None
-            and self.instance.member.date_of_birth != self.cleaned_data["birthdate"]
+            and self.instance.member.date_of_birth is None
         ):
             self.instance.member.date_of_birth = self.cleaned_data["birthdate"]
             self.instance.member.save()

--- a/subscription/static/bundled/subscription/creation-form-existing-user-index.ts
+++ b/subscription/static/bundled/subscription/creation-form-existing-user-index.ts
@@ -1,3 +1,5 @@
+import { userFetchUser } from "#openapi";
+
 document.addEventListener("alpine:init", () => {
   Alpine.data("existing_user_subscription_form", () => ({
     loading: false,
@@ -12,13 +14,24 @@ document.addEventListener("alpine:init", () => {
     },
 
     async loadProfile(userId: number) {
+      const birthdayInput = document.getElementById("id_birthdate") as HTMLInputElement;
       if (!Number.isInteger(userId)) {
         this.profileFragment = "";
+        birthdayInput.hidden = true;
         return;
       }
       this.loading = true;
-      const response = await fetch(`/user/${userId}/mini/`);
-      this.profileFragment = await response.text();
+      const [miniProfile, userInfos] = await Promise.all([
+        fetch(`/user/${userId}/mini/`),
+        // biome-ignore lint/style/useNamingConvention: api is snake_case
+        userFetchUser({ path: { user_id: userId } }),
+      ]);
+      this.profileFragment = await miniProfile.text();
+      // If the user has no birthdate yet, show the form input
+      // to fill this info.
+      // Else keep the input hidden and change its value to the user birthdate
+      birthdayInput.value = userInfos.data.date_of_birth;
+      birthdayInput.hidden = userInfos.data.date_of_birth !== null;
       this.loading = false;
     },
   }));

--- a/subscription/static/subscription/css/subscription.scss
+++ b/subscription/static/subscription/css/subscription.scss
@@ -23,6 +23,11 @@
      * then display the user profile right in the middle of the remaining space. */
     fieldset {
       flex: 0 1 auto;
+
+      p:has(input[hidden]) {
+        // when the input is hidden, hide the whole label+input+help text group
+        display: none;
+      }
     }
 
     #subscription-form-user-mini-profile {

--- a/subscription/static/subscription/css/subscription.scss
+++ b/subscription/static/subscription/css/subscription.scss
@@ -1,4 +1,14 @@
 #subscription-form form {
+  margin-top: 0;
+
+  .form-content {
+    margin-top: 0;
+  }
+
+  fieldset p:first-of-type, & > p:first-of-type {
+    margin-top: 0;
+  }
+
   .form-content.existing-user {
     max-height: 100%;
     display: flex;


### PR DESCRIPTION
Oblige à renseigner la date de naissance lors de la création d'une cotisation pour un utilisateur existant si ce dernier ne l'a pas déjà donnée.

Exemple :
<img width="482" height="673" alt="image" src="https://github.com/user-attachments/assets/8d1997fd-80d3-4cac-b972-12952b745c64" />

Pour ne pas surcharger le formulaire, l'input pour la date de naissance est caché quand aucun utilisateur n'est sélectionné ou que l'utilisateur sélectionné a déjà une date de naissance renseignée.

<img width="447" height="563" alt="image" src="https://github.com/user-attachments/assets/78d5acca-5669-467d-b908-35b6dbd0c928" />


