### PR TITLE
Com notification

### DIFF
--- a/com/ics_calendar.py
+++ b/com/ics_calendar.py
@@ -68,7 +68,7 @@ class IcsCalendar:
                 start=news_date.start_date,
                 end=news_date.end_date,
                 url=as_absolute_url(
-                    reverse("com:news_detail", kwargs={"news_id": news_date.news.id})
+                    reverse("com:news_detail", kwargs={"news_id": news_date.news_id})
                 ),
             )
             calendar.events.append(event)

--- a/com/tests/test_notifications.py
+++ b/com/tests/test_notifications.py
@@ -1,13 +1,22 @@
+from datetime import timedelta
+
 import pytest
 from django.conf import settings
+from django.utils.timezone import now
 from model_bakery import baker
 
-from com.models import News
+from com.models import News, NewsDate
+from core.baker_recipes import subscriber_user
 from core.models import Group, Notification, User
 
 
 @pytest.mark.django_db
 def test_notification_created():
+    # this news is unpublished, but is set in the past
+    # it shouldn't be taken into account when counting the number
+    # of news that are to be moderated
+    past_news = baker.make(News, is_published=False)
+    baker.make(NewsDate, news=past_news, start_date=now() - timedelta(days=1))
     com_admin_group = Group.objects.get(pk=settings.SITH_GROUP_COM_ADMIN_ID)
     com_admin_group.users.all().delete()
     Notification.objects.all().delete()
@@ -15,9 +24,28 @@ def test_notification_created():
     for i in range(2):
         # news notifications are permanent, so the notification created
         # during the first iteration should be reused during the second one.
-        baker.make(News)
+        baker.make(News, is_published=False)
         notifications = list(Notification.objects.all())
         assert len(notifications) == 1
         assert notifications[0].user == com_admin
         assert notifications[0].type == "NEWS_MODERATION"
         assert notifications[0].param == str(i + 1)
+
+
+@pytest.mark.django_db
+def test_notification_edited_when_moderating_news():
+    com_admin_group = Group.objects.get(pk=settings.SITH_GROUP_COM_ADMIN_ID)
+    com_admins = subscriber_user.make(_quantity=3)
+    com_admin_group.users.set(com_admins)
+    Notification.objects.all().delete()
+    news = baker.make(News, is_published=False)
+    assert Notification.objects.count() == 3
+    assert Notification.objects.filter(viewed=False).count() == 3
+
+    news.is_published = True
+    news.moderator = com_admins[0]
+    news.save()
+    # when the news is moderated, the notification should be marked as read
+    # for all admins
+    assert Notification.objects.count() == 3
+    assert Notification.objects.filter(viewed=False).count() == 0

--- a/sith/settings.py
+++ b/sith/settings.py
@@ -686,8 +686,10 @@ SITH_NOTIFICATIONS = [
 # The keys are the notification names as found in SITH_NOTIFICATIONS, and the
 # values are the callback function to update the notifs.
 # The callback must take the notif object as first and single argument.
+# If a notification is permanent but requires no post-action, set the
+# callback import string as None
 SITH_PERMANENT_NOTIFICATIONS = {
-    "NEWS_MODERATION": "com.models.news_notification_callback",
+    "NEWS_MODERATION": None,
     "SAS_MODERATION": "sas.models.sas_notification_callback",
 }
 


### PR DESCRIPTION
- la création des notifications faisait un N+1 queries
- le décompte du nombre de nouvelles à modérer était mauvais
- modérer une nouvelle ne modifiait pas les notifications des autres admins (maintenant, si un admin modère toutes les nouvelles, alors les admins qui passeront après ne verront pas leur notif)
- la génération de l'ICS faisait un N+1 queries