### PR TITLE
Include only subscribed users and their direct relations in the galaxy

### DIFF
--- a/galaxy/management/commands/rule_galaxy.py
+++ b/galaxy/management/commands/rule_galaxy.py
@@ -45,8 +45,9 @@ class Command(BaseCommand):
                 "verbosity level should be between 0 and 2 included", stacklevel=2
             )
 
-        if options["verbosity"] == 2:
+        if options["verbosity"] >= 2:
             logger.setLevel(logging.DEBUG)
+            logging.getLogger("django.db.backends").setLevel(logging.DEBUG)
         elif options["verbosity"] == 1:
             logger.setLevel(logging.INFO)
         else:
@@ -59,6 +60,3 @@ class Command(BaseCommand):
         Galaxy.objects.filter(state__isnull=True).delete()
 
         logger.info("Ruled the galaxy in {} queries.".format(len(connection.queries)))
-        if options["verbosity"] > 2:
-            for q in connection.queries:
-                logger.debug(q)

--- a/galaxy/tests.py
+++ b/galaxy/tests.py
@@ -122,7 +122,7 @@ class TestGalaxyModel(TestCase):
             self.com,
         ]
 
-        with self.assertNumQueries(44):
+        with self.assertNumQueries(38):
             while len(users) > 0:
                 user1 = users.pop(0)
                 family_scores = Galaxy.compute_user_family_score(user1)
@@ -150,7 +150,7 @@ class TestGalaxyModel(TestCase):
         that the number of queries to rule the galaxy is stable.
         """
         galaxy = Galaxy.objects.create()
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(36):
             galaxy.rule(0)  # We want everybody here
 
 


### PR DESCRIPTION
Si la galaxie a trop d'utilisateurs, la visualisation devient illisible et mange toutes les ressources de la machine. Donc, pour restreindre les utilisateurs de la galaxie, on n'y inclut que les utilisateurs cotisants+les utilisateurs qui sont directement liés à des utilisateurs cotisants.