### PR TITLE
Htmx club

### DIFF
--- a/club/models.py
+++ b/club/models.py
@@ -30,7 +30,8 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import RegexValidator, validate_email
 from django.db import models, transaction
-from django.db.models import Exists, F, OuterRef, Q
+from django.db.models import Exists, F, OuterRef, Q, Value
+from django.db.models.functions import Greatest
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -243,6 +244,41 @@ class MembershipQuerySet(models.QuerySet):
         """
         return self.filter(role__gt=settings.SITH_MAXIMUM_FREE_ROLE)
 
+    def editable_by(self, user: User) -> Self:
+        """Filter Memberships that this user can edit.
+
+        Users with the `club.change_membership` permission can edit all Membership.
+        The other users can end :
+        - their own membership
+        - if they are board members, memberships with a role lower than their own
+
+        For example, let's suppose the following users :
+        - A : board member
+        - B : board member
+        - C : simple member
+        - D : curious
+
+        A will be able to end the memberships of A, C and D ;
+        C and D will be able to end only their own membership.
+        """
+        if user.has_perm("club.change_membership"):
+            return self.all()
+        return self.filter(
+            Exists(
+                Membership.objects.filter(
+                    Q(
+                        role__gt=Greatest(
+                            OuterRef("role"), Value(settings.SITH_MAXIMUM_FREE_ROLE)
+                        )
+                    )
+                    | Q(pk=OuterRef("pk")),
+                    user=user,
+                    end_date=None,
+                    club=OuterRef("club"),
+                )
+            )
+        )
+
     def update(self, **kwargs) -> int:
         """Refresh the cache and edit group ownership.
 
@@ -319,16 +355,12 @@ class Membership(models.Model):
         User,
         verbose_name=_("user"),
         related_name="memberships",
-        null=False,
-        blank=False,
         on_delete=models.CASCADE,
     )
     club = models.ForeignKey(
         Club,
         verbose_name=_("club"),
         related_name="members",
-        null=False,
-        blank=False,
         on_delete=models.CASCADE,
     )
     start_date = models.DateField(_("start date"), default=timezone.now)

--- a/club/models.py
+++ b/club/models.py
@@ -201,10 +201,6 @@ class Club(models.Model):
         """Method to see if that object can be edited by the given user."""
         return self.has_rights_in_club(user)
 
-    def can_be_viewed_by(self, user: User) -> bool:
-        """Method to see if that object can be seen by the given user."""
-        return user.was_subscribed
-
     def get_membership_for(self, user: User) -> Membership | None:
         """Return the current membership the given user.
 

--- a/club/static/club/members.scss
+++ b/club/static/club/members.scss
@@ -1,0 +1,24 @@
+#club_members_table {
+  tbody label {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+#add_club_members_form {
+  fieldset {
+    display: flex;
+    flex-direction: row;
+    column-gap: 2em;
+    row-gap: 1em;
+    flex-wrap: wrap;
+
+    @media (max-width: 1100px) {
+      justify-content: space-evenly;
+    }
+
+    .errorlist {
+      max-width: 300px;
+    }
+  }
+}

--- a/club/templates/club/club_members.jinja
+++ b/club/templates/club/club_members.jinja
@@ -1,15 +1,25 @@
 {% extends "core/base.jinja" %}
 {% from 'core/macros.jinja' import user_profile_link, select_all_checkbox %}
 
+{% block additional_js %}
+  <script type="module" src="{{ static("bundled/core/components/ajax-select-index.ts") }}"></script>
+{% endblock %}
+{% block additional_css %}
+  <link rel="stylesheet" href="{{ static("bundled/core/components/ajax-select-index.css") }}">
+  <link rel="stylesheet" href="{{ static("core/components/ajax-select.scss") }}">
+{% endblock %}
+
 {% block content %}
   <h2>{% trans %}Club members{% endtrans %}</h2>
+  <br />
+  {{ add_member_fragment }}
+  <br />
   {% if members %}
-    <form action="{{ url('club:club_members', club_id=club.id) }}" id="users_old" method="post">
+    <form action="{{ url('club:club_members', club_id=club.id) }}" id="members_old" method="post">
       {% csrf_token %}
-      {% set users_old = dict(form.users_old | groupby("choice_label")) %}
-      {% if users_old %}
-        {{ select_all_checkbox("users_old") }}
-        <p></p>
+      {% if can_end_membership %}
+        {{ select_all_checkbox("members_old") }}
+        <br />
       {% endif %}
       <table id="club_members_table">
         <thead>
@@ -18,7 +28,7 @@
             <td>{% trans %}Role{% endtrans %}</td>
             <td>{% trans %}Description{% endtrans %}</td>
             <td>{% trans %}Since{% endtrans %}</td>
-            {% if users_old %}
+            {% if can_end_membership %}
               <td>{% trans %}Mark as old{% endtrans %}</td>
             {% endif %}
           </tr>
@@ -30,20 +40,24 @@
               <td>{{ settings.SITH_CLUB_ROLES[m.role] }}</td>
               <td>{{ m.description }}</td>
               <td>{{ m.start_date }}</td>
-              {% if users_old %}
+              {%- if can_end_membership -%}
                 <td>
-                  {% set user_old = users_old[m.user.get_display_name()] %}
-                  {% if user_old %}
-                    {{ user_old[0].tag() }}
-                  {% endif %}
+                  {%- if m.is_editable -%}
+                    <label for="id_members_old_{{ loop.index }}"></label>
+                    <input
+                      type="checkbox"
+                      name="members_old"
+                      value="{{ m.id }}"
+                      id="id_members_old_{{ loop.index }}"
+                    >
+                  {%- endif -%}
                 </td>
-              {% endif %}
+              {%- endif -%}
             </tr>
           {% endfor %}
         </tbody>
       </table>
-      {{ form.users_old.errors }}
-      {% if users_old %}
+      {% if can_end_membership %}
         <p></p>
         <input type="submit" name="submit" value="{% trans %}Mark as old{% endtrans %}">
       {% endif %}
@@ -51,32 +65,4 @@
   {% else %}
     <p>{% trans %}There are no members in this club.{% endtrans %}</p>
   {% endif %}
-  <form action="{{ url('club:club_members', club_id=club.id) }}" id="add_users" method="post">
-    {% csrf_token %}
-    {{ form.non_field_errors() }}
-    <p>
-      {{ form.users.errors }}
-      <label for="{{ form.users.id_for_label }}">{{ form.users.label }} :</label>
-      {{ form.users }}
-      <span class="helptext">{{ form.users.help_text }}</span>
-    </p>
-    <p>
-      {{ form.role.errors }}
-      <label for="{{ form.role.id_for_label }}">{{ form.role.label }} :</label>
-      {{ form.role }}
-    </p>
-    {% if form.start_date %}
-      <p>
-        {{ form.start_date.errors }}
-        <label for="{{ form.start_date.id_for_label }}">{{ form.start_date.label }} :</label>
-        {{ form.start_date }}
-      </p>
-    {% endif %}
-    <p>
-      {{ form.description.errors }}
-      <label for="{{ form.description.id_for_label }}">{{ form.description.label }} :</label>
-      {{ form.description }}
-    </p>
-    <p><input type="submit" value="{% trans %}Add{% endtrans %}" /></p>
-  </form>
 {% endblock %}

--- a/club/templates/club/club_members.jinja
+++ b/club/templates/club/club_members.jinja
@@ -7,11 +7,14 @@
 {% block additional_css %}
   <link rel="stylesheet" href="{{ static("bundled/core/components/ajax-select-index.css") }}">
   <link rel="stylesheet" href="{{ static("core/components/ajax-select.scss") }}">
+  <link rel="stylesheet" href="{{ static("club/members.scss") }}">
 {% endblock %}
 
 {% block content %}
   <h2>{% trans %}Club members{% endtrans %}</h2>
   <br />
+  <h4>{% trans %}Add a new member{% endtrans %}</h4>
+
   {{ add_member_fragment }}
   <br />
   {% if members %}

--- a/club/templates/club/club_members.jinja
+++ b/club/templates/club/club_members.jinja
@@ -12,11 +12,13 @@
 
 {% block content %}
   <h2>{% trans %}Club members{% endtrans %}</h2>
-  <br />
-  <h4>{% trans %}Add a new member{% endtrans %}</h4>
 
-  {{ add_member_fragment }}
-  <br />
+  {% if add_member_fragment %}
+    <br />
+    <h4>{% trans %}Add a new member{% endtrans %}</h4>
+    {{ add_member_fragment }}
+    <br />
+  {% endif %}
   {% if members %}
     <form action="{{ url('club:club_members', club_id=club.id) }}" id="members_old" method="post">
       {% csrf_token %}

--- a/club/templates/club/club_old_members.jinja
+++ b/club/templates/club/club_old_members.jinja
@@ -5,20 +5,22 @@
   <h2>{% trans %}Club old members{% endtrans %}</h2>
   <table>
     <thead>
-      <td>{% trans %}User{% endtrans %}</td>
-      <td>{% trans %}Role{% endtrans %}</td>
-      <td>{% trans %}Description{% endtrans %}</td>
-      <td>{% trans %}From{% endtrans %}</td>
-      <td>{% trans %}To{% endtrans %}</td>
+      <tr>
+        <td>{% trans %}User{% endtrans %}</td>
+        <td>{% trans %}Role{% endtrans %}</td>
+        <td>{% trans %}Description{% endtrans %}</td>
+        <td>{% trans %}From{% endtrans %}</td>
+        <td>{% trans %}To{% endtrans %}</td>
+      </tr>
     </thead>
     <tbody>
-      {% for m in club.members.exclude(end_date=None).order_by('-role', 'description', '-end_date').all() %}
+      {% for member in old_members %}
         <tr>
-          <td>{{ user_profile_link(m.user) }}</td>
-          <td>{{ settings.SITH_CLUB_ROLES[m.role] }}</td>
-          <td>{{ m.description }}</td>
-          <td>{{ m.start_date }}</td>
-          <td>{{ m.end_date }}</td>
+          <td>{{ user_profile_link(member.user) }}</td>
+          <td>{{ settings.SITH_CLUB_ROLES[member.role] }}</td>
+          <td>{{ member.description }}</td>
+          <td>{{ member.start_date }}</td>
+          <td>{{ member.end_date }}</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/club/templates/club/fragments/add_member.jinja
+++ b/club/templates/club/fragments/add_member.jinja
@@ -1,3 +1,18 @@
+{% if messages %}
+  <div x-data="{show_alert: true}" class="alert alert-green" x-show="show_alert" x-transition>
+    <span class="alert-main">
+      {% for message in messages %}
+        {% if message.level_tag == "success" %}
+          {{ message }}
+        {% endif %}
+      {% endfor %}
+    </span>
+    <span class="clickable" @click="show_alert = false">
+      <i class="fa fa-close"></i>
+    </span>
+  </div>
+{% endif %}
+
 <form
   hx-post="{{ url('club:club_new_members', club_id=club.id) }}"
   hx-disabled-elt="find input[type='submit']"
@@ -7,7 +22,6 @@
   {% csrf_token %}
   {{ form.non_field_errors() }}
   <fieldset>
-
     <div>
       {{ form.user.label_tag()}}
       <span class="helptext">{{ form.user.help_text }}</span>

--- a/club/templates/club/fragments/add_member.jinja
+++ b/club/templates/club/fragments/add_member.jinja
@@ -1,0 +1,27 @@
+<h4>{% trans %}Add a new member{% endtrans %}</h4>
+<form
+  hx-post="{{ url('club:club_new_members', club_id=club.id) }}"
+  hx-disabled-elt="find input[type='submit']"
+  hx-swap="outerHTML"
+  id="add_users"
+>
+  {% csrf_token %}
+  {{ form.non_field_errors() }}
+  <p>
+    {{ form.user.errors }}
+    {{ form.user.label_tag()}}
+    <span class="helptext">{{ form.user.help_text }}</span>
+    {{ form.user }}
+  </p>
+  <p>
+    {{ form.role.errors }}
+    {{ form.role.label_tag()}}
+    {{ form.role }}
+  </p>
+  <p>
+    {{ form.description.errors }}
+    {{ form.description.label_tag()}}
+    {{ form.description }}
+  </p>
+  <p><input type="submit" /></p>
+</form>

--- a/club/templates/club/fragments/add_member.jinja
+++ b/club/templates/club/fragments/add_member.jinja
@@ -1,27 +1,30 @@
-<h4>{% trans %}Add a new member{% endtrans %}</h4>
 <form
   hx-post="{{ url('club:club_new_members', club_id=club.id) }}"
   hx-disabled-elt="find input[type='submit']"
   hx-swap="outerHTML"
-  id="add_users"
+  id="add_club_members_form"
 >
   {% csrf_token %}
   {{ form.non_field_errors() }}
-  <p>
-    {{ form.user.errors }}
-    {{ form.user.label_tag()}}
-    <span class="helptext">{{ form.user.help_text }}</span>
-    {{ form.user }}
-  </p>
-  <p>
-    {{ form.role.errors }}
-    {{ form.role.label_tag()}}
-    {{ form.role }}
-  </p>
-  <p>
-    {{ form.description.errors }}
-    {{ form.description.label_tag()}}
-    {{ form.description }}
-  </p>
-  <p><input type="submit" /></p>
+  <fieldset>
+
+    <div>
+      {{ form.user.label_tag()}}
+      <span class="helptext">{{ form.user.help_text }}</span>
+      {{ form.user }}
+      {{ form.user.errors }}
+    </div>
+    <div>
+      {{ form.role.label_tag()}}
+      {{ form.role }}
+      {{ form.role.errors }}
+    </div>
+    <div>
+      {{ form.description.label_tag()}}
+      {{ form.description }}
+      {{ form.description.errors }}
+    </div>
+  </fieldset>
+  <button type="submit" class="btn btn-blue">
+    <i class="fa fa-user-plus"></i> {% trans %}Add{% endtrans %}</button>
 </form>

--- a/club/tests/base.py
+++ b/club/tests/base.py
@@ -43,6 +43,9 @@ class TestClub(TestCase):
 
         cls.ae = Club.objects.get(pk=settings.SITH_MAIN_CLUB_ID)
         cls.club = baker.make(Club)
+        cls.new_members_url = reverse(
+            "club:club_new_members", kwargs={"club_id": cls.club.id}
+        )
         cls.members_url = reverse("club:club_members", kwargs={"club_id": cls.club.id})
         a_month_ago = now() - timedelta(days=30)
         yesterday = now() - timedelta(days=1)

--- a/club/tests/test_membership.py
+++ b/club/tests/test_membership.py
@@ -353,7 +353,7 @@ class TestMembership(TestClub):
 
         assert not form.is_valid()
         assert form.errors == {
-            "__all__": ["Vous n'avez pas la permission de faire cela"]
+            "role": ["Sélectionnez un choix valide. 10 n\u2019en fait pas partie."]
         }
         self.club.refresh_from_db()
         assert nb_memberships == self.club.members.count()

--- a/club/tests/test_membership.py
+++ b/club/tests/test_membership.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.timezone import localdate, localtime, now
 from model_bakery import baker
+from pytest_django.asserts import assertRedirects
 
 from club.forms import ClubMemberForm
 from club.models import Club, Membership
@@ -185,7 +186,7 @@ class TestMembership(TestClub):
 
     def assert_membership_ended_today(self, user: User):
         """Assert that the given user have a membership which ended today."""
-        today = localtime(now()).date()
+        today = localdate()
         assert user.memberships.filter(club=self.club, end_date=today).exists()
         assert self.club.get_membership_for(user) is None
 
@@ -194,7 +195,9 @@ class TestMembership(TestClub):
         cannot see the page.
         """
         response = self.client.post(self.members_url)
-        assert response.status_code == 403
+        assertRedirects(
+            response, reverse("core:login", query={"next": self.members_url})
+        )
 
         self.client.force_login(self.public)
         response = self.client.post(self.members_url)
@@ -205,7 +208,9 @@ class TestMembership(TestClub):
         information are displayed.
         """
         self.client.force_login(self.simple_board_member)
-        response = self.client.get(self.members_url)
+        response = self.client.get(
+            reverse("club:club_members", kwargs={"club_id": self.club.id})
+        )
         assert response.status_code == 200
         soup = BeautifulSoup(response.text, "lxml")
         table = soup.find("table", id="club_members_table")
@@ -231,42 +236,30 @@ class TestMembership(TestClub):
             assert cols[2].text == membership.description
             assert cols[3].text == str(membership.start_date)
 
-            if membership.role <= 3:  # 3 is the role of simple_board_member
+            if membership.role < 3 or membership.user_id == self.simple_board_member.id:
+                # 3 is the role of simple_board_member
                 form_input = cols[4].find("input")
                 expected_attrs = {
                     "type": "checkbox",
-                    "name": "users_old",
-                    "value": str(user.id),
+                    "name": "members_old",
+                    "value": str(membership.id),
                 }
                 assert form_input.attrs.items() >= expected_attrs.items()
             else:
                 assert cols[4].find_all() == []
 
     def test_root_add_one_club_member(self):
-        """Test that root users can add members to clubs, one at a time."""
+        """Test that root users can add members to clubs"""
         self.client.force_login(self.root)
         response = self.client.post(
-            self.members_url,
-            {"users": [self.subscriber.id], "role": 3},
+            self.new_members_url, {"user": self.subscriber.id, "role": 3}
         )
-        self.assertRedirects(response, self.members_url)
+        assert response.status_code == 200
+        assert response.headers.get("HX-Redirect", "") == reverse(
+            "club:club_members", kwargs={"club_id": self.club.id}
+        )
         self.subscriber.refresh_from_db()
         self.assert_membership_started_today(self.subscriber, role=3)
-
-    def test_root_add_multiple_club_member(self):
-        """Test that root users can add multiple members at once to clubs."""
-        self.client.force_login(self.root)
-        response = self.client.post(
-            self.members_url,
-            {
-                "users": (self.subscriber.id, self.krophil.id),
-                "role": 3,
-            },
-        )
-        self.assertRedirects(response, self.members_url)
-        self.subscriber.refresh_from_db()
-        self.assert_membership_started_today(self.subscriber, role=3)
-        self.assert_membership_started_today(self.krophil, role=3)
 
     def test_add_unauthorized_members(self):
         """Test that users who are not currently subscribed
@@ -274,16 +267,14 @@ class TestMembership(TestClub):
         """
         for user in self.public, self.old_subscriber:
             form = ClubMemberForm(
-                data={"users": [user.id], "role": 1},
+                data={"user": user.id, "role": 1},
                 request_user=self.root,
                 club=self.club,
             )
 
             assert not form.is_valid()
             assert form.errors == {
-                "users": [
-                    "L'utilisateur doit être cotisant pour faire partie d'un club"
-                ]
+                "user": ["L'utilisateur doit être cotisant pour faire partie d'un club"]
             }
 
     def test_add_members_already_members(self):
@@ -316,15 +307,15 @@ class TestMembership(TestClub):
         max_id = User.objects.aggregate(id=Max("id"))["id"]
         for members in [max_id + 1], [max_id + 1, self.subscriber.id]:
             form = ClubMemberForm(
-                data={"users": members, "role": 1},
+                data={"user": members, "role": 1},
                 request_user=self.root,
                 club=self.club,
             )
             assert not form.is_valid()
             assert form.errors == {
-                "users": [
+                "user": [
                     "Sélectionnez un choix valide. "
-                    f"{max_id + 1} n\u2019en fait pas partie."
+                    "Ce choix ne fait pas partie de ceux disponibles."
                 ]
             }
         self.club.refresh_from_db()
@@ -337,10 +328,12 @@ class TestMembership(TestClub):
         nb_subscriber_memberships = self.subscriber.memberships.count()
         self.client.force_login(president)
         response = self.client.post(
-            self.members_url,
-            {"users": self.subscriber.id, "role": 9},
+            self.new_members_url, {"user": self.subscriber.id, "role": 9}
         )
-        self.assertRedirects(response, self.members_url)
+        assert response.status_code == 200
+        assert response.headers.get("HX-Redirect", "") == reverse(
+            "club:club_members", kwargs={"club_id": self.club.id}
+        )
         self.club.refresh_from_db()
         self.subscriber.refresh_from_db()
         assert self.club.members.count() == nb_club_membership + 1
@@ -352,7 +345,7 @@ class TestMembership(TestClub):
         a membership with a greater role than its own.
         """
         form = ClubMemberForm(
-            data={"users": [self.subscriber.id], "role": 10},
+            data={"user": self.subscriber.id, "role": 10},
             request_user=self.simple_board_member,
             club=self.club,
         )
@@ -368,23 +361,18 @@ class TestMembership(TestClub):
 
     def test_add_member_without_role(self):
         """Test that trying to add members without specifying their role fails."""
-        self.client.force_login(self.root)
         form = ClubMemberForm(
-            data={"users": [self.subscriber.id]},
-            request_user=self.simple_board_member,
-            club=self.club,
+            data={"user": self.subscriber.id}, request_user=self.root, club=self.club
         )
 
         assert not form.is_valid()
-        assert form.errors == {"role": ["Vous devez choisir un rôle"]}
+        assert form.errors == {"role": ["Ce champ est obligatoire."]}
 
     def test_end_membership_self(self):
         """Test that a member can end its own membership."""
         self.client.force_login(self.simple_board_member)
-        self.client.post(
-            self.members_url,
-            {"users_old": self.simple_board_member.id},
-        )
+        membership = self.club.members.get(end_date=None, user=self.simple_board_member)
+        self.client.post(self.members_url, {"members_old": [membership.id]})
         self.simple_board_member.refresh_from_db()
         self.assert_membership_ended_today(self.simple_board_member)
 
@@ -392,15 +380,13 @@ class TestMembership(TestClub):
         """Test that board members of the club can end memberships
         of users with lower roles.
         """
-        # remainder : simple_board_member has role 3, president has role 10, richard has role 1
+        # reminder : simple_board_member has role 3
         self.client.force_login(self.simple_board_member)
-        response = self.client.post(
-            self.members_url,
-            {"users_old": self.richard.id},
-        )
+        membership = baker.make(Membership, club=self.club, role=2, end_date=None)
+        response = self.client.post(self.members_url, {"members_old": [membership.id]})
         self.assertRedirects(response, self.members_url)
         self.club.refresh_from_db()
-        self.assert_membership_ended_today(self.richard)
+        self.assert_membership_ended_today(membership.user)
 
     def test_end_membership_higher_role(self):
         """Test that board members of the club cannot end memberships
@@ -408,46 +394,30 @@ class TestMembership(TestClub):
         """
         membership = self.president.memberships.filter(club=self.club).first()
         self.client.force_login(self.simple_board_member)
-        self.client.post(
-            self.members_url,
-            {"users_old": self.president.id},
-        )
+        self.client.post(self.members_url, {"members_old": [membership.id]})
         self.club.refresh_from_db()
         new_membership = self.club.get_membership_for(self.president)
         assert new_membership is not None
         assert new_membership == membership
 
-        membership = self.president.memberships.filter(club=self.club).first()
+        membership.refresh_from_db()
         assert membership.end_date is None
 
-    def test_end_membership_as_main_club_board(self):
-        """Test that board members of the main club can end the membership
-        of anyone.
-        """
+    def test_end_membership_with_permission(self):
+        """Test that users with permission can end any membership."""
         # make subscriber a board member
-        subscriber = subscriber_user.make()
-        Membership.objects.create(club=self.ae, user=subscriber, role=3)
-
         nb_memberships = self.club.members.ongoing().count()
-        self.client.force_login(subscriber)
+        self.client.force_login(
+            subscriber_user.make(
+                user_permissions=[Permission.objects.get(codename="change_membership")]
+            )
+        )
+        president_membership = self.club.president
         response = self.client.post(
-            self.members_url,
-            {"users_old": self.president.id},
+            self.members_url, {"members_old": [president_membership.id]}
         )
         self.assertRedirects(response, self.members_url)
-        self.assert_membership_ended_today(self.president)
-        assert self.club.members.ongoing().count() == nb_memberships - 1
-
-    def test_end_membership_as_root(self):
-        """Test that root users can end the membership of anyone."""
-        nb_memberships = self.club.members.ongoing().count()
-        self.client.force_login(self.root)
-        response = self.client.post(
-            self.members_url,
-            {"users_old": [self.president.id]},
-        )
-        self.assertRedirects(response, self.members_url)
-        self.assert_membership_ended_today(self.president)
+        self.assert_membership_ended_today(president_membership.user)
         assert self.club.members.ongoing().count() == nb_memberships - 1
 
     def test_end_membership_as_foreigner(self):
@@ -455,14 +425,11 @@ class TestMembership(TestClub):
         nb_memberships = self.club.members.count()
         membership = self.richard.memberships.filter(club=self.club).first()
         self.client.force_login(self.subscriber)
-        self.client.post(
-            self.members_url,
-            {"users_old": [self.richard.id]},
-        )
+        self.client.post(self.members_url, {"members_old": [self.richard.id]})
         # nothing should have changed
-        new_mem = self.club.get_membership_for(self.richard)
+        membership.refresh_from_db()
         assert self.club.members.count() == nb_memberships
-        assert membership == new_mem
+        assert membership.end_date is None
 
     def test_remove_from_club_group(self):
         """Test that when a membership ends, the user is removed from club groups."""

--- a/club/urls.py
+++ b/club/urls.py
@@ -25,6 +25,7 @@
 from django.urls import path
 
 from club.views import (
+    ClubAddMembersFragment,
     ClubCreateView,
     ClubEditView,
     ClubListView,
@@ -60,6 +61,11 @@ urlpatterns = [
     path("<int:club_id>/edit/", ClubEditView.as_view(), name="club_edit"),
     path("<int:club_id>/edit/page/", ClubPageEditView.as_view(), name="club_edit_page"),
     path("<int:club_id>/members/", ClubMembersView.as_view(), name="club_members"),
+    path(
+        "fragment/<int:club_id>/members/",
+        ClubAddMembersFragment.as_view(),
+        name="club_new_members",
+    ),
     path(
         "<int:club_id>/elderlies/",
         ClubOldMembersView.as_view(),

--- a/club/views.py
+++ b/club/views.py
@@ -342,6 +342,15 @@ class ClubOldMembersView(ClubTabsMixin, PermissionRequiredMixin, DetailView):
     current_tab = "elderlies"
     permission_required = "club.view_club"
 
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {
+            "old_members": (
+                self.object.members.exclude(end_date=None)
+                .order_by("-role", "description", "-end_date")
+                .select_related("user")
+            )
+        }
+
 
 class ClubSellingView(ClubTabsMixin, CanEditMixin, DetailFormView):
     """Sellings of a club."""

--- a/club/views.py
+++ b/club/views.py
@@ -69,7 +69,7 @@ from com.views import (
 from core.auth.mixins import CanCreateMixin, CanEditMixin
 from core.models import PageRev
 from core.views import DetailFormView, PageEditViewBase, UseFragmentsMixin
-from core.views.mixins import FragmentMixin, TabedViewMixin
+from core.views.mixins import FragmentMixin, FragmentRenderer, TabedViewMixin
 from counter.models import Selling
 
 
@@ -301,8 +301,13 @@ class ClubMembersView(
     form_class = ClubOldMemberForm
     template_name = "club/club_members.jinja"
     current_tab = "members"
-    fragments = {"add_member_fragment": ClubAddMembersFragment}
     permission_required = "club.view_club"
+
+    def get_fragments(self) -> dict[str, type[FragmentMixin] | FragmentRenderer]:
+        membership = self.object.get_membership_for(self.request.user)
+        if membership and membership.role <= settings.SITH_MAXIMUM_FREE_ROLE:
+            return {}
+        return {"add_member_fragment": ClubAddMembersFragment}
 
     def get_fragment_data(self) -> dict[str, Any]:
         return {"add_member_fragment": {"club": self.object}}

--- a/club/views.py
+++ b/club/views.py
@@ -23,12 +23,13 @@
 #
 
 import csv
+from typing import Any
 
 from django.conf import settings
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.exceptions import NON_FIELD_ERRORS, PermissionDenied, ValidationError
 from django.core.paginator import InvalidPage, Paginator
-from django.db.models import Sum
+from django.db.models import Q, Sum
 from django.http import (
     Http404,
     HttpResponseRedirect,
@@ -37,7 +38,8 @@ from django.http import (
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
-from django.utils.functional import cached_property
+from django.utils.safestring import SafeString
+from django.utils.timezone import now
 from django.utils.translation import gettext as _t
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, ListView, View
@@ -47,20 +49,26 @@ from club.forms import (
     ClubAdminEditForm,
     ClubEditForm,
     ClubMemberForm,
+    ClubOldMemberForm,
     MailingForm,
     SellingsForm,
 )
-from club.models import Club, Mailing, MailingSubscription, Membership
+from club.models import (
+    Club,
+    Mailing,
+    MailingSubscription,
+    Membership,
+)
 from com.views import (
     PosterCreateBaseView,
     PosterDeleteBaseView,
     PosterEditBaseView,
     PosterListBaseView,
 )
-from core.auth.mixins import CanCreateMixin, CanEditMixin, CanViewMixin
+from core.auth.mixins import CanCreateMixin, CanEditMixin
 from core.models import PageRev
-from core.views import DetailFormView, PageEditViewBase
-from core.views.mixins import TabedViewMixin
+from core.views import DetailFormView, PageEditViewBase, UseFragmentsMixin
+from core.views.mixins import FragmentMixin, TabedViewMixin
 from counter.models import Selling
 
 
@@ -79,7 +87,7 @@ class ClubTabsMixin(TabedViewMixin):
                 "name": _("Infos"),
             }
         ]
-        if self.request.user.can_view(self.object):
+        if self.request.user.has_perm("club.view_club"):
             tab_list.extend(
                 [
                     {
@@ -98,16 +106,16 @@ class ClubTabsMixin(TabedViewMixin):
                     },
                 ]
             )
-        if self.object.page:
-            tab_list.append(
-                {
-                    "url": reverse(
-                        "club:club_hist", kwargs={"club_id": self.object.id}
-                    ),
-                    "slug": "history",
-                    "name": _("History"),
-                }
-            )
+            if self.object.page:
+                tab_list.append(
+                    {
+                        "url": reverse(
+                            "club:club_hist", kwargs={"club_id": self.object.id}
+                        ),
+                        "slug": "history",
+                        "name": _("History"),
+                    }
+                )
         if self.request.user.can_edit(self.object):
             tab_list.extend(
                 [
@@ -228,13 +236,14 @@ class ClubPageEditView(ClubTabsMixin, PageEditViewBase):
         return reverse_lazy("club:club_view", kwargs={"club_id": self.club.id})
 
 
-class ClubPageHistView(ClubTabsMixin, CanViewMixin, DetailView):
+class ClubPageHistView(ClubTabsMixin, PermissionRequiredMixin, DetailView):
     """Modification hostory of the page."""
 
     model = Club
     pk_url_kwarg = "club_id"
     template_name = "club/page_history.jinja"
     current_tab = "history"
+    permission_required = "club.view_club"
 
 
 class ClubToolsView(ClubTabsMixin, CanEditMixin, DetailView):
@@ -246,57 +255,92 @@ class ClubToolsView(ClubTabsMixin, CanEditMixin, DetailView):
     current_tab = "tools"
 
 
-class ClubMembersView(ClubTabsMixin, CanViewMixin, DetailFormView):
+class ClubAddMembersFragment(FragmentMixin, PermissionRequiredMixin, CreateView):
+    template_name = "club/fragments/add_member.jinja"
+    form_class = ClubMemberForm
+    model = Membership
+    object = None
+    reload_on_redirect = True
+    permission_required = "club.view_club"
+
+    def dispatch(self, *args, **kwargs):
+        club_id = self.kwargs.get("club_id")
+        if not club_id:
+            raise Http404
+        self.club = get_object_or_404(Club, pk=kwargs.get("club_id"))
+        return super().dispatch(*args, **kwargs)
+
+    def get_form_kwargs(self):
+        return super().get_form_kwargs() | {
+            "request_user": self.request.user,
+            "club": self.club,
+        }
+
+    def render_fragment(self, request, **kwargs) -> SafeString:
+        self.club = kwargs.get("club")
+        return super().render_fragment(request, **kwargs)
+
+    def get_success_url(self):
+        return reverse("club:club_members", kwargs={"club_id": self.club.id})
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {"club": self.club}
+
+
+class ClubMembersView(
+    ClubTabsMixin, UseFragmentsMixin, PermissionRequiredMixin, DetailFormView
+):
     """View of a club's members."""
 
     model = Club
     pk_url_kwarg = "club_id"
-    form_class = ClubMemberForm
+    form_class = ClubOldMemberForm
     template_name = "club/club_members.jinja"
     current_tab = "members"
+    fragments = {"add_member_fragment": ClubAddMembersFragment}
+    permission_required = "club.view_club"
 
-    @cached_property
-    def members(self) -> list[Membership]:
-        return list(self.object.members.ongoing().order_by("-role"))
+    def get_fragment_data(self) -> dict[str, Any]:
+        return {"add_member_fragment": {"club": self.object}}
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs["request_user"] = self.request.user
+        kwargs["user"] = self.request.user
         kwargs["club"] = self.object
-        kwargs["club_members"] = self.members
         return kwargs
 
     def get_context_data(self, **kwargs):
         kwargs = super().get_context_data(**kwargs)
-        kwargs["members"] = self.members
+        editable = list(
+            kwargs["form"].fields["members_old"].queryset.values_list("id", flat=True)
+        )
+        kwargs["members"] = list(
+            self.object.members.ongoing()
+            .annotate(is_editable=Q(id__in=editable))
+            .order_by("-role")
+            .select_related("user")
+        )
+        kwargs["can_end_membership"] = len(editable) > 0
         return kwargs
 
     def form_valid(self, form):
-        """Check user rights."""
-        resp = super().form_valid(form)
-
-        data = form.clean()
-        users = data.pop("users", [])
-        users_old = data.pop("users_old", [])
-        for user in users:
-            Membership(club=self.object, user=user, **data).save()
-        for user in users_old:
-            membership = self.object.get_membership_for(user)
-            membership.end_date = timezone.now()
+        for membership in form.cleaned_data.get("members_old"):
+            membership.end_date = now()
             membership.save()
-        return resp
+        return super().form_valid(form)
 
     def get_success_url(self, **kwargs):
         return self.request.path
 
 
-class ClubOldMembersView(ClubTabsMixin, CanViewMixin, DetailView):
+class ClubOldMembersView(ClubTabsMixin, PermissionRequiredMixin, DetailView):
     """Old members of a club."""
 
     model = Club
     pk_url_kwarg = "club_id"
     template_name = "club/club_old_members.jinja"
     current_tab = "elderlies"
+    permission_required = "club.view_club"
 
 
 class ClubSellingView(ClubTabsMixin, CanEditMixin, DetailFormView):
@@ -686,8 +730,10 @@ class MailingAutoGenerationView(View):
         return redirect("club:mailing", club_id=club.id)
 
 
-class PosterListView(ClubTabsMixin, PosterListBaseView, CanViewMixin):
+class PosterListView(ClubTabsMixin, PermissionRequiredMixin, PosterListBaseView):
     """List communication posters."""
+
+    permission_required = "club.view_club"
 
     def get_object(self):
         return self.club
@@ -704,7 +750,7 @@ class PosterCreateView(PosterCreateBaseView, CanCreateMixin):
 
     pk_url_kwarg = "club_id"
 
-    def get_object(self):
+    def get_object(self, *args, **kwargs):
         obj = super().get_object()
         if not obj:
             return self.club

--- a/club/views.py
+++ b/club/views.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from django.conf import settings
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import NON_FIELD_ERRORS, PermissionDenied, ValidationError
 from django.core.paginator import InvalidPage, Paginator
 from django.db.models import Q, Sum
@@ -255,13 +256,16 @@ class ClubToolsView(ClubTabsMixin, CanEditMixin, DetailView):
     current_tab = "tools"
 
 
-class ClubAddMembersFragment(FragmentMixin, PermissionRequiredMixin, CreateView):
+class ClubAddMembersFragment(
+    FragmentMixin, PermissionRequiredMixin, SuccessMessageMixin, CreateView
+):
     template_name = "club/fragments/add_member.jinja"
     form_class = ClubMemberForm
     model = Membership
     object = None
     reload_on_redirect = True
     permission_required = "club.view_club"
+    success_message = _("%(user)s has been added to club.")
 
     def dispatch(self, *args, **kwargs):
         club_id = self.kwargs.get("club_id")

--- a/core/static/core/components/ajax-select.scss
+++ b/core/static/core/components/ajax-select.scss
@@ -36,6 +36,7 @@
   > .ts-control {
     box-shadow: none;
     max-width: 300px;
+    width: 300px;
     background-color: var(--nf-input-background-color);
 
     &::after {

--- a/core/static/core/forms.scss
+++ b/core/static/core/forms.scss
@@ -47,6 +47,7 @@
   }
 
   input,
+  select,
   textarea[type="text"],
   [type="number"],
   .ts-control {
@@ -239,6 +240,23 @@ form {
         width: 95%;
       }
     }
+  }
+  input[type="text"],
+  input[type="email"],
+  input[type="tel"],
+  input[type="url"],
+  input[type="password"],
+  input[type="number"],
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="week"],
+  input[type="time"],
+  input[type="month"],
+  input[type="search"],
+  textarea,
+  select,
+  .ts-control {
+    min-height: calc(var(--nf-input-size) * 2.5);
   }
 
   input[type="text"],

--- a/core/static/core/style.scss
+++ b/core/static/core/style.scss
@@ -517,6 +517,10 @@ th {
   >ul {
     margin-top: 0;
   }
+
+  >input[type="checkbox"] {
+    padding: unset;
+  }
 }
 
 td {

--- a/eboutic/static/bundled/eboutic/eboutic-index.ts
+++ b/eboutic/static/bundled/eboutic/eboutic-index.ts
@@ -17,7 +17,8 @@ document.addEventListener("alpine:init", () => {
       this.$watch("basket", () => {
         this.saveBasket();
       });
-
+      console.log(lastPurchaseTime);
+      console.log(localStorage.basketTimestamp);
       // Invalidate basket if a purchase was made
       if (lastPurchaseTime !== null && localStorage.basketTimestamp !== undefined) {
         if (

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-13 15:18+0200\n"
+"POT-Creation-Date: 2025-09-13 18:32+0200\n"
 "PO-Revision-Date: 2016-07-18\n"
 "Last-Translator: Maréchal <thomas.girod@utbm.fr\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -173,6 +173,13 @@ msgstr "L'utilisateur doit être cotisant pour faire partie d'un club"
 msgid "You can not add the same user twice"
 msgstr "Vous ne pouvez pas ajouter deux fois le même utilisateur"
 
+#: club/forms.py
+msgid ""
+"You cannot add other users to a club if you are not in the club board."
+msgstr ""
+"Vous ne pouvez pas ajouter d'autres utilisateurs dans un club si vous "
+"ne faites pas partie de son bureau."
+
 #: club/forms.py sas/forms.py
 msgid "You do not have the permission to do that"
 msgstr "Vous n'avez pas la permission de faire cela"
@@ -325,10 +332,6 @@ msgstr "Membres du club"
 #: club/templates/club/club_members.jinja
 msgid "Add a new member"
 msgstr "Ajouter un nouveau membre"
-
-#: club/templates/club/club_members.jinja
-msgid "Current club members"
-msgstr "Membres actuels du club"
 
 #: club/templates/club/club_members.jinja
 #: club/templates/club/club_old_members.jinja
@@ -683,6 +686,11 @@ msgstr "Listes de diffusion"
 #: club/views.py com/views.py
 msgid "Posters list"
 msgstr "Liste d'affiches"
+
+#: club/views.py
+#, python-format
+msgid "%(user)s has been added to club."
+msgstr "%(user)s a été ajouté au club."
 
 #: com/forms.py
 msgid "Format: 16:9 | Resolution: 1920x1080"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-13 14:43+0200\n"
+"POT-Creation-Date: 2025-09-13 15:18+0200\n"
 "PO-Revision-Date: 2016-07-18\n"
 "Last-Translator: Maréchal <thomas.girod@utbm.fr\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-01 18:18+0200\n"
+"POT-Creation-Date: 2025-09-13 14:43+0200\n"
 "PO-Revision-Date: 2016-07-18\n"
 "Last-Translator: Maréchal <thomas.girod@utbm.fr\n"
 "Language-Team: AE info <ae.info@utbm.fr>\n"
@@ -173,10 +173,6 @@ msgstr "L'utilisateur doit être cotisant pour faire partie d'un club"
 msgid "You can not add the same user twice"
 msgstr "Vous ne pouvez pas ajouter deux fois le même utilisateur"
 
-#: club/forms.py
-msgid "You should specify a role"
-msgstr "Vous devez choisir un rôle"
-
 #: club/forms.py sas/forms.py
 msgid "You do not have the permission to do that"
 msgstr "Vous n'avez pas la permission de faire cela"
@@ -327,6 +323,14 @@ msgid "Club members"
 msgstr "Membres du club"
 
 #: club/templates/club/club_members.jinja
+msgid "Add a new member"
+msgstr "Ajouter un nouveau membre"
+
+#: club/templates/club/club_members.jinja
+msgid "Current club members"
+msgstr "Membres actuels du club"
+
+#: club/templates/club/club_members.jinja
 #: club/templates/club/club_old_members.jinja
 #: core/templates/core/user_clubs.jinja
 #: trombi/templates/trombi/edit_profile.jinja
@@ -349,11 +353,6 @@ msgstr "Depuis"
 #: club/templates/club/club_members.jinja
 msgid "There are no members in this club."
 msgstr "Il n'y a pas de membres dans ce club."
-
-#: club/templates/club/club_members.jinja core/templates/core/file_detail.jinja
-#: core/views/forms.py trombi/templates/trombi/detail.jinja
-msgid "Add"
-msgstr "Ajouter"
 
 #: club/templates/club/club_old_members.jinja
 msgid "Club old members"
@@ -568,6 +567,12 @@ msgstr ""
 #: trombi/templates/trombi/user_tools.jinja
 msgid "Save"
 msgstr "Sauver"
+
+#: club/templates/club/fragments/add_member.jinja
+#: core/templates/core/file_detail.jinja core/views/forms.py
+#: trombi/templates/trombi/detail.jinja
+msgid "Add"
+msgstr "Ajouter"
 
 #: club/templates/club/mailing.jinja
 msgid "Mailing lists"
@@ -1713,8 +1718,8 @@ msgid ""
 "AE UTBM is a voluntary organisation run by UTBM students. It organises "
 "student life at UTBM and manages its student facilities."
 msgstr ""
-"L'AE UTBM est une association bénévole gérée par les étudiants de "
-"l'UTBM. Elle organise la vie étudiante de l'UTBM et gère ses lieux de vie."
+"L'AE UTBM est une association bénévole gérée par les étudiants de l'UTBM. "
+"Elle organise la vie étudiante de l'UTBM et gère ses lieux de vie."
 
 #: core/templates/core/base/footer.jinja core/templates/core/base/navbar.jinja
 msgid "Contacts"
@@ -2156,10 +2161,6 @@ msgstr ""
 #: core/templates/core/page_hist.jinja
 msgid "Page history"
 msgstr "Historique de la page"
-
-#: core/templates/core/page_list.jinja
-msgid "There is no page in this website."
-msgstr "Il n'y a pas de page sur ce site web."
 
 #: core/templates/core/page_prop.jinja
 msgid "Page properties"


### PR DESCRIPTION
HTMXification de la page des membres d'un club.

Le formulaire pour ajouter des utilisateurs est extrait dans son propre fragment, avec son propre formulaire, ce qui simplifie beaucoup la gestion.

Le formulaire est également déplacé d'en-dessous de la liste des membres vers au-dessus et son style un peu amélioré.
<img width="1335" height="529" alt="image" src="https://github.com/user-attachments/assets/53014405-bb2d-4bcb-9c6a-08e970d372c5" />

Les choix des rôles attribuables sont déterminés dynamiquement :
- un admin et le président du club peuvent donner n'importe quel rôle à n'importe qui
- les membres du bureau peuvent donner des rôles inférieurs au leur
- les non-membres peuvent se donner les rôles membre et curieux

Un membre qui n'est pas au bureau ne peut ajouter personne d'autre et ne peut plus s'ajouter lui-même (vu qu'il est déjà là), donc on lui cache le formulaire.

Pour les autres, seuls les rôles que l'utilisateur peut donner lui sont montrés :
<img width="824" height="356" alt="image" src="https://github.com/user-attachments/assets/fd0f151e-6007-41cc-8811-36d0dcc7bcc8" />

