### PR TITLE
Cache user photos

### DIFF
--- a/sas/templates/sas/user_pictures.jinja
+++ b/sas/templates/sas/user_pictures.jinja
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block content %}
-  <main x-data="user_pictures({ userId: {{ object.id }} })">
+  <main x-data="user_pictures({ userId: {{ object.id }}, nbPictures: {{ object.nb_pictures }} })">
     {% if user.id == object.id %}
       {{ download_button(_("Download all my pictures")) }}
     {% endif %}

--- a/sas/views.py
+++ b/sas/views.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.db.models import Count, OuterRef, Subquery
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -36,7 +37,7 @@ from sas.forms import (
     PictureModerationRequestForm,
     PictureUploadForm,
 )
-from sas.models import Album, Picture
+from sas.models import Album, PeoplePictureRelation, Picture
 
 
 class AlbumCreateFragment(FragmentMixin, CreateView):
@@ -178,6 +179,13 @@ class UserPicturesView(UserTabsMixin, CanViewMixin, DetailView):
     context_object_name = "profile"
     template_name = "sas/user_pictures.jinja"
     current_tab = "pictures"
+    queryset = User.objects.annotate(
+        nb_pictures=Subquery(
+            PeoplePictureRelation.objects.filter(user=OuterRef("id"))
+            .values("user_id")
+            .values(count=Count("*"))
+        )
+    ).all()
 
 
 # Admin views


### PR DESCRIPTION
J'ai constaté que les personnes qui consultent leurs anciennes photos le font de la manière suivante : ils vont sur la liste de leurs photos (la liste charge), ils regardent une photo, puis ils font retour arrière (la liste recharge), puis ils regardent une autre photo, et ainsi de suite.

Sur mon navigateur, quand je retourne sur une page antérieure très peu de temps après l'avoir quitté, il n'y a pas de nouvelle requête et l'ancienne page est re-affichée directement, ce qui fait que je n'avais pas vu le problème. Mais chez d'autres personnes, il y la requête à l'API qui est faite à chaque fois, ce qui donne un temps de latence avec roue de chargement.

Donc, dans cette PR, je rajoute une étape de vérification du localStorage, avec invalidation si une nouvelle photo a été ajoutée