### PR TITLE
fix: 500 on page properties edit

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1275,12 +1275,9 @@ class Page(models.Model):
     def __str__(self):
         return self.get_full_name()
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, force_lock: bool = False, **kwargs):
         """Performs some needed actions before and after saving a page in database."""
-        locked = kwargs.pop("force_lock", False)
-        if not locked:
-            locked = self.is_locked()
-        if not locked:
+        if not force_lock and not self.is_locked():
             raise NotLocked("The page is not locked and thus can not be saved")
         self.full_clean()
         if not self.id:
@@ -1292,7 +1289,7 @@ class Page(models.Model):
         # It also update all the children to maintain correct names
         self._full_name = self.get_full_name()
         for c in self.children.all():
-            c.save()
+            c.save(force_lock=force_lock)
         super().save(*args, **kwargs)
         self.unset_lock()
 
@@ -1408,14 +1405,14 @@ class Page(models.Model):
     def need_club_redirection(self):
         return self.is_club_page and self.name != settings.SITH_CLUB_ROOT_PAGE
 
-    def delete(self):
+    def delete(self, *args, **kwargs):
         self.unset_lock_recursive()
         self.set_lock_recursive(User.objects.get(id=0))
         for child in self.children.all():
             child.parent = self.parent
             child.save()
             child.unset_lock_recursive()
-        super().delete()
+        return super().delete(*args, **kwargs)
 
 
 class PageRev(models.Model):
@@ -1462,8 +1459,11 @@ class PageRev(models.Model):
     def get_absolute_url(self):
         return reverse("core:page", kwargs={"page_name": self.page._full_name})
 
-    def can_be_edited_by(self, user):
+    def can_be_edited_by(self, user: User) -> bool:
         return self.page.can_be_edited_by(user)
+
+    def is_owned_by(self, user: User) -> bool:
+        return any(g.id == self.page.owner_group_id for g in user.cached_groups)
 
 
 def get_notification_types():

--- a/core/tests/test_page.py
+++ b/core/tests/test_page.py
@@ -1,0 +1,26 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+from model_bakery import baker
+from pytest_django.asserts import assertRedirects
+
+from core.baker_recipes import board_user
+from core.models import Page
+
+
+@pytest.mark.django_db
+def test_edit_page(client: Client):
+    user = board_user.make()
+    page = baker.prepare(Page)
+    page.save(force_lock=True)
+    page.view_groups.add(user.groups.first())
+    client.force_login(user)
+
+    url = reverse("core:page_edit", kwargs={"page_name": page._full_name})
+    res = client.get(url)
+    assert res.status_code == 200
+
+    res = client.post(url, data={"content": "Hello World"})
+    assertRedirects(res, reverse("core:page", kwargs={"page_name": page._full_name}))
+    revision = page.revisions.last()
+    assert revision.content == "Hello World"

--- a/core/views/page.py
+++ b/core/views/page.py
@@ -184,7 +184,7 @@ class PageEditViewBase(CanEditMixin, UpdateView):
     )
     template_name = "core/pagerev_edit.jinja"
 
-    def get_object(self):
+    def get_object(self, *args, **kwargs):
         self.page = Page.get_page_by_full_name(self.kwargs["page_name"])
         return self._get_revision()
 


### PR DESCRIPTION
Le mécanisme de vérification des droits essayait de récupérer `PageRev.owner_group_id`, qui n'existe pas. J'ai réparé ça sommairement en rajoutant la méthode `PageRev.is_owned_by`, mais c'est vraiment juste un bout de scotch placé là. Pour vraiment réparer ça, il faudrait tout réécrire.