### PR TITLE
fix(counter): forbid special price higher than normal price on Product

### DIFF
--- a/counter/forms.py
+++ b/counter/forms.py
@@ -447,6 +447,27 @@ class ProductForm(forms.ModelForm):
             self.fields[key].widget.attrs["max"] = price
             self.fields[key].validators.append(MaxValueValidator(price))
 
+    def clean(self):
+        cleaned_data = super().clean()
+        # The "special price" is the discounted price for AE members; it
+        # should never be higher than the regular `selling_price`. The
+        # form previously accepted that combination silently (issue #1361).
+        selling_price = cleaned_data.get("selling_price")
+        special_selling_price = cleaned_data.get("special_selling_price")
+        if (
+            selling_price is not None
+            and special_selling_price is not None
+            and special_selling_price > selling_price
+        ):
+            self.add_error(
+                "special_selling_price",
+                _(
+                    "The special price must not be higher than "
+                    "the regular selling price."
+                ),
+            )
+        return cleaned_data
+
     def is_valid(self):
         return super().is_valid() and self.action_formset.is_valid()
 

--- a/counter/tests/test_product.py
+++ b/counter/tests/test_product.py
@@ -120,6 +120,21 @@ class TestCreateProduct(TestCase):
         assert instance.name == "foo"
         assert instance.selling_price == 1.0
 
+    def test_special_price_cannot_exceed_normal_price(self):
+        # Regression for #1361: the form silently accepted a
+        # special_selling_price higher than the regular selling_price,
+        # which is nonsense for the AE-member discount it represents.
+        data = self.data | {"selling_price": 1.0, "special_selling_price": 2.0}
+        form = ProductForm(data=data)
+        assert not form.is_valid()
+        assert "special_selling_price" in form.errors
+
+    def test_special_price_equal_to_normal_price_is_allowed(self):
+        # Equality is fine — a product that simply has no member discount.
+        data = self.data | {"selling_price": 1.5, "special_selling_price": 1.5}
+        form = ProductForm(data=data)
+        assert form.is_valid()
+
     def test_form_with_product_from_formula(self):
         """Test when the edited product is a result of a formula."""
         self.client.force_login(self.counter_admin)


### PR DESCRIPTION
## Summary

Closes #1361.

\`ProductForm\` silently accepted a \`special_selling_price\` higher
than the regular \`selling_price\`. The \"special\" price is the
discounted AE-member price, so the inverse relationship is
meaningless and produced the kind of result the issue screenshot
shows — a product priced *more* for AE members than for non-members.

## Fix

Add a \`clean()\` method on \`ProductForm\` that flags the
impossible combination on the \`special_selling_price\` field.
Equality stays allowed — a product with no member discount is a
valid configuration. The new check sits alongside the existing
formula-bound \`MaxValueValidator\` so both validations run on the
same submit; the formula path through \`formula_init\` is
unchanged.

## Test plan

Two regression tests in
\`counter/tests/test_product.py::TestProductForm\`:

- [x] \`test_special_price_cannot_exceed_normal_price\` — submit
      \`selling_price=1.0\`, \`special_selling_price=2.0\`, assert
      the form is invalid and \`special_selling_price\` is in
      \`form.errors\`.
- [x] \`test_special_price_equal_to_normal_price_is_allowed\` —
      equality represents the no-discount case and stays valid.

I don't have a Django/Postgres environment wired up here to run the
suite locally, so I'm relying on CI for the runtime check. The
existing \`test_form\` and \`test_form_with_product_from_formula\`
cases use \`selling_price\` and \`special_selling_price\` values
that already satisfy the new rule (\`1.0/1.0\` and the formula case
keeps the special below the normal), so they shouldn't regress.