### PR TITLE
refactor: use rolldown builtin `inject`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "@babel/preset-env": "^7.29.2",
         "@biomejs/biome": "^2.4.13",
         "@hey-api/openapi-ts": "^0.94.5",
-        "@rollup/plugin-inject": "^5.0.5",
         "@types/alpinejs": "^3.13.11",
         "@types/cytoscape-cxtmenu": "^3.4.5",
         "@types/cytoscape-klay": "^3.1.5",
@@ -2383,52 +2382,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/plugin-inject": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
-      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@sentry-internal/browser-utils": {
       "version": "10.51.0",
       "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.51.0.tgz",
@@ -3378,13 +3331,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4073,16 +4019,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/marked": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@babel/preset-env": "^7.29.2",
     "@biomejs/biome": "^2.4.13",
     "@hey-api/openapi-ts": "^0.94.5",
-    "@rollup/plugin-inject": "^5.0.5",
     "@types/alpinejs": "^3.13.11",
     "@types/cytoscape-cxtmenu": "^3.4.5",
     "@types/cytoscape-klay": "^3.1.5",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,5 +1,4 @@
 import { parse, resolve } from "node:path";
-import inject from "@rollup/plugin-inject";
 import { glob } from "glob";
 import { visualizer } from "rollup-plugin-visualizer";
 import {
@@ -81,14 +80,8 @@ export default defineConfig((config: UserConfig) => {
     resolve: {
       alias: getAliases(),
     },
-
-    plugins: [
-      inject({
-        // biome-ignore lint/style/useNamingConvention: that's how it's called
-        Alpine: "alpinejs",
-        htmx: "htmx.org",
-      }),
-      visualizer({ filename: ".bundle-size-report.html" }) as PluginOption,
-    ],
+    // biome-ignore lint/style/useNamingConvention: that's how it's called
+    inject: { Alpine: "alpinejs", htmx: "htmx.org" },
+    plugins: [visualizer({ filename: ".bundle-size-report.html" }) as PluginOption],
   } satisfies UserConfig;
 });


### PR DESCRIPTION
`inject` est builtin dans rolldown maintenant, donc plus besoin d'un plugin