### PR TITLE
fix: `QuotaExceededError` on user pictures load

### DIFF
--- a/sas/static/bundled/sas/user/pictures-index.ts
+++ b/sas/static/bundled/sas/user/pictures-index.ts
@@ -35,8 +35,23 @@ document.addEventListener("alpine:init", () => {
         // biome-ignore lint/style/useNamingConvention: from python api
         query: { users_identified: [config.userId] },
       } as PicturesFetchPicturesData);
-      localStorage.setItem(localStorageInvalidationKey, config.nbPictures.toString());
-      localStorage.setItem(localStorageKey, JSON.stringify(pictures));
+      try {
+        localStorage.setItem(localStorageInvalidationKey, config.nbPictures.toString());
+        localStorage.setItem(localStorageKey, JSON.stringify(pictures));
+      } catch {
+        // an exception is raised if the localstorage is entirely filled
+        // so just delete all cached user pictures.
+        // A cache hit is not worth the page breaking.
+        Object.keys(localStorage)
+          .filter(
+            (key) =>
+              key.startsWith("user") &&
+              (key.endsWith("Pictures") || key.endsWith("PicturesNumber")),
+          )
+          .forEach((key) => {
+            localStorage.removeItem(key);
+          });
+      }
       return pictures;
     },
 


### PR DESCRIPTION
C'est un quick fix, pour au moins permettre que la page ne crash pas. Dans l'idéal, il faudrait une meilleure gestion du localStorage sur cette page, mais ça prendrait plus de temps, donc je fais déjà ça. J'implémenterai le truc complet plus tard.