### PR TITLE
fix: duplicate user search when a whitelist exists

### DIFF
--- a/core/tests/test_user.py
+++ b/core/tests/test_user.py
@@ -141,6 +141,22 @@ class TestSearchUsersView(TestSearchUsers):
         response = self.client.get(reverse("core:search"))
         assert response.status_code == 200
 
+    def test_search_with_whitelist_unique(self):
+        """Test that when a user has a whitelist and appears in the results,
+        it appears only once.
+
+        This is a regression test (cf #1463)
+        """
+        user = subscriber_user.make(is_viewable=False)
+        user.whitelisted_users.add(
+            *subscriber_user.make(_quantity=4, _bulk_create=True)
+        )
+        self.client.force_login(user)
+        response = self.client.get(
+            reverse("core:search", query={"query": user.last_name})
+        )
+        assert response.context_data["users"] == [user]
+
 
 @pytest.mark.django_db
 def test_user_account_not_found(client: Client):

--- a/core/views/index.py
+++ b/core/views/index.py
@@ -65,6 +65,7 @@ class SearchView(LoginRequiredMixin, TemplateView):
                 UserFilterSchema(search=query)
                 .filter(User.objects.viewable_by(self.request.user))
                 .order_by(F("last_login").desc(nulls_last=True))
+                .distinct()
             )
             clubs = list(Club.objects.filter(name__icontains=query)[:5])
         return super().get_context_data(**kwargs) | {"users": users, "clubs": clubs}


### PR DESCRIPTION
Quand un utilisateur possède une whitelist d'utilisateurs, qu'il effectue une recherche et qu'il apparait dans les résultats, son profil apparait plusieurs fois.

Exemple : 
<img width="475" height="556" alt="image" src="https://github.com/user-attachments/assets/343ac215-5573-479e-99d1-7bf469178a65" />
