### PR TITLE
fix: timetable

### DIFF
--- a/timetable/static/bundled/timetable/generator-index.ts
+++ b/timetable/static/bundled/timetable/generator-index.ts
@@ -1,8 +1,8 @@
 import html2canvas from "html2canvas";
 
-// see https://regex101.com/r/QHSaPM/2
+// see https://regex101.com/r/QHSaPM/3
 const TIMETABLE_ROW_RE: RegExp =
-  /^(?<ueCode>\w.+\w)\s+(?<courseType>[A-Z]{2}\d)\s+((?<weekGroup>[AB])\s+)?(?<weekday>(lundi)|(mardi)|(mercredi)|(jeudi)|(vendredi)|(samedi)|(dimanche))\s+(?<startHour>\d{2}:\d{2})\s+(?<endHour>\d{2}:\d{2})\s+[\dA-B]\s+((?<attendance>[\wé]*)\s+)?(?<room>\w+(?:, \w+)?)$/;
+  /^(?<ueCode>\w.+\w)\s+(?<courseType>[A-Z]{2}\d)\s+((?<weekGroup>[AB])\s+)?(?<weekday>(lundi)|(mardi)|(mercredi)|(jeudi)|(vendredi)|(samedi)|(dimanche))\s+(?<startHour>\d{2}:\d{2})\s+(?<endHour>\d{2}:\d{2})\s+[\dA-B]\s+((?<attendance>[\wé]*)\s+)?(?<room>\w+(?:, \w+)*)$/;
 
 const DEFAULT_TIMETABLE: string = `DS52\t\tCM1\t\tlundi\t08:00\t10:00\t1\tPrésentiel\tA113
 DS53\t\tCM1\t\tlundi\t10:15\t12:15\t1\tPrésentiel\tA101

--- a/timetable/views.py
+++ b/timetable/views.py
@@ -1,8 +1,6 @@
 # Create your views here.
 from django.views.generic import TemplateView
 
-from core.auth.mixins import FormerSubscriberMixin
 
-
-class GeneratorView(FormerSubscriberMixin, TemplateView):
+class GeneratorView(TemplateView):
     template_name = "timetable/generator.jinja"


### PR DESCRIPTION
Le regex échouait en cas de plus de deux salles différentes indiquées (`PI40        TP4        jeudi    08:00    12:00    1    Présentiel    LS002, P016, P017, P021, R301`)

Le générateur est aussi mis plus largement à disposition.